### PR TITLE
[1주차] yyj-Leetcode-1642

### DIFF
--- a/Leetcode/1642/yyj.py
+++ b/Leetcode/1642/yyj.py
@@ -1,0 +1,24 @@
+class Solution:
+    def furthestBuilding(self, heights: List[int], bricks: int, ladders: int) -> int:
+        minheap = []
+        used_bricks_if_reach_building_i = 0
+        
+        for i in range(len(heights)-1):
+            diff = heights[i+1] - heights[i]
+            
+            #diff <= 0 : no restriction, just move to the next building
+            
+            if diff > 0:
+                if len(minheap) < ladders:
+                    heapq.heappush(minheap, diff)
+                else:
+                    if minheap and diff > minheap[0]:
+                        usebrick = heapq.heapreplace(minheap, diff)
+                        used_bricks_if_reach_building_i += usebrick
+                    else:
+                        used_bricks_if_reach_building_i += diff
+                        
+                if used_bricks_if_reach_building_i > bricks:
+                    return i
+        
+        return len(heights)-1


### PR DESCRIPTION
## 문제 링크


[https://leetcode.com/problems/furthest-building-you-can-reach/](https://leetcode.com/problems/furthest-building-you-can-reach/)



## 어려움을 겪은 내용

### 1. Dealing with edge cases

- ladders 값이 0일 경우를 미리 생각하지 않아서 처음 작성한 코드

```python
if diff > minheap[0]:
    #minheap[0]을 diff로 교체
```

🤪 ladders = 0으로 주어진 테스트케이스를 돌리면 indexError 발생

### 2. Min heap 업데이트

- 1번 문제점을 해결한 후의 코드

```python
if minheap and diff > minheap[0]:
    heapq.heapreplace(minheap, diff)
else:
    used_bricks_if_reach_next_building += diff
```

💩 실행은 되지만 반환값이 맞지 않다

틀린 답이 나올 때 원래 답보다 큰 값이 나오는 것으로 보아 뭔가 빠뜨리고 있을 확률이 높다



## 해결 방법

### 1. Min heap에 원소가 있는지부터 확인

- ladders = 0일 경우, 이 부분은 실행되지 않으며 minheap은 비어 있는 상태로 유지된다

```python
heapq.heappush(minheap, diff)
```

- ladders = 0이면 사용 가능한 사다리가 주어지지 않았다는 뜻으로, 사다리 사용 스텝 후보를 검토/교체할 필요가 없다
- minheap[0]을 조회하기 전 minheap에 원소가 있는지부터 확인하도록 하자

```python
if minheap and diff > minheap[0]:
    #minheap[0]을 diff로 교체
```

### 2. Min heap을 업데이트할 때 힙에서 꺼낸 값은 사용한 brick 수에 더하기

- 기존 코드는 minheap[0]을 diff(i)로 대체하면서 힙에서 꺼내진 minheap[0]을 고려하지 않음
- minheap[0]은 [ diff(0) ... diff(i-1) ] 중 한 값이므로 이미 지나온 스텝임
- 해당 스텝에 대해 사다리를 쓸 수 없게 되었다면 벽돌을 쓴다고 가정해 주어야 모든 스텝이 정상 수행 상태가 된다

```python
if minheap and diff > minheap[0]:
    usebrick = heapq.heapreplace(minheap, diff)
    used_bricks_if_reach_next_building += usebrick
else:
    used_bricks_if_reach_next_building += diff
```

🥰 ~~신난다 응애에요~~