### PR TITLE
[3주차] yyj-Leetcode-740

### DIFF
--- a/Leetcode/740/yyj.py
+++ b/Leetcode/740/yyj.py
@@ -1,0 +1,17 @@
+class Solution:
+    def deleteAndEarn(self, nums: List[int]) -> int:
+        c = collections.Counter(nums)
+        scores = [0 for i in range(10001)]
+        for n in c:
+            scores[n] = n * c[n]
+        
+        def dp(n):
+            if n < 2:
+                return max(scores[:n+1])
+            if n not in mem:
+                mem[n] = max(dp(n-1), dp(n-2)+scores[n])
+            return mem[n]
+        
+        mem = {}
+        
+        return dp(len(scores)-1)


### PR DESCRIPTION
## 문제
https://leetcode.com/problems/delete-and-earn/

## 어려움을 겪은 내용

### 1. input 가공

배열의 인덱스는 문제 풀이에 관계가 없는 요소이기 때문에 정렬 혹은 다른 형태로 가공하면 풀이가 용이해질 것 같은데 방법이 잘 생각나지 않았다.

## 해결 방법

### 1. 조건 시뮬레이션으로 규칙 발견하기

문제에서 주어진 조건대로 시뮬레이션을 하면서 실마리를 찾을 수 있었다.

- 주어진 배열이 정수 배열이므로 N을 지울 때 간접 삭제되는 N-1, N+1은 정수 전체를 크기 순으로 나열했을 때 N에 이웃한 두 수라고 할 수 있다.
- 값이 N인 원소를 처음으로 선택하여 지울 때,
    - 이웃한 두 값(N-1, N+1)을 가진 원소는 전부 삭제되며 이 값들과 관련된 포인트 획득은 없다.
    - 남아있는 N이 간접 삭제되는 경우는 N-1이나 N+1의 직접 삭제뿐인데, 모든 N-1, N+1은 이미 삭제되었으므로 불가능하다.
    - 이에 따라 주어진 배열 내의 값이 N인 모든 원소는 직접 삭제하여야 한다.
        - 획득 포인트 : N * count(N)

이에 따라, 문제의 조건을 다음과 같이 재해석할 수 있게 된다.

- 주어진 배열로 점수 배열을 만든다.
    - scores[N] = N * count(N)
- 점수 배열의 칸을 연속되지 않게 선택할 때, 선택한 값의 합이 최대가 되게 한다.

이제 익숙한 DP 문제가 되었다🥰

*※ 비슷한 문제 : 198. House Robber*

    https://leetcode.com/problems/house-robber/
