### PR TITLE
[4주차] yyj-Leetcode-994

### DIFF
--- a/Leetcode/994/yyj.py
+++ b/Leetcode/994/yyj.py
@@ -1,0 +1,34 @@
+class Solution:
+    def orangesRotting(self, grid: List[List[int]]) -> int:
+        def is_valid_coord(r: int, c: int) -> bool:
+            return 0 <= r < row and 0 <= c < col
+        
+        row, col = len(grid), len(grid[0])
+        fresh = 0
+        elapsed_time = 0
+        move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        
+        q = collections.deque()
+        
+        for r in range(row):
+            for c in range(col):
+                fresh += grid[r][c] % 2
+                if grid[r][c] == 2:
+                    q.append([r, c])
+                    
+        while fresh:
+            elapsed_time += 1
+            is_newly_rotten = False
+            for _ in range(len(q)):
+                r, c = q.popleft()
+                for x, y in move:
+                    next_r, next_c = r+x, c+y
+                    if is_valid_coord(next_r, next_c) and grid[next_r][next_c] == 1:
+                        grid[next_r][next_c] = 2
+                        fresh -= 1
+                        is_newly_rotten = True
+                        q.append([next_r, next_c])
+            if not is_newly_rotten:
+                return -1
+                    
+        return elapsed_time


### PR DESCRIPTION
## 문제

https://leetcode.com/problems/rotting-oranges/

## 개요

- 0 : 빈칸 / 1 : 싱싱한 오렌지 / 2 : 상한 오렌지
- 매 분마다 상한 오렌지(2)의 동서남북 방향으로 인접한 싱싱한 오렌지(1)는 상한 오렌지(2)가 된다
- 모든 오렌지가 상하는 데 걸리는 시간(분)을 리턴하며, 불가능할 경우 -1을 리턴한다
    - 모든 오렌지가 상할 수 없는 경우에 대한 검증과 처리 필요

## 어려움을 겪은 내용

### 1. 모든 오렌지가 상할 수 없는 경우에 대한 효율적 검증과 처리

모든 오렌지가 상할 수 없는 경우를 어떻게 확인할까?

가장 쉽게 생각할 수 있는 방법은 BFS를 한 번 돌리고, 격자판 전제를 스캔하여 싱싱한 오렌지(1)가 남아있는지 확인하는 작업을 반복하는 것이다.

N-1회차 BFS 이후 남은 싱싱한 오렌지(1)의 수와 N회차 BFS 이후 남은 싱싱한 오렌지(1)의 수가 같다면, 상한 상태의 전파가 더 이상 진행되지 않을 것이다.

하지만 매번 격자판 전체를 스캔하는 것보다 더 효율적인 방법을 찾으면 좋겠다.

## 해결 방법

### 1. 상태를 나타내는 적절한 변수 활용

 다음 두 변수를 활용하였다.

- fresh(type: int) : 싱싱한 오렌지(1)의 수. 초기값은 처음에 주어진 격자판 전체를 스캔하여 만들고, 기본적으로 이 값이 0이 될 때까지 BFS를 돌리게 한다
- is_newly_rotten(type: bool) : BFS를 한 번 돌리는 동안 상하는 오렌지가 있는지(=큐에 들어가는 좌표가 있는지) 나타내는 변수

처음에는 int타입 변수 두 개를 사용하여 이전 회차 BFS 직후와 이번 회차 BFS 직후의 싱싱한 오렌지 수를 비교하려고 했는데, 변화가 있는지만 확인하면 되므로 변화가 있다/없다 두 가지 상태를 표현하는 변수만으로도 충분하겠다는 생각이 들었다.

```python
fresh = 0
for r in range(row):
    for c in range(col):
    fresh += grid[r][c] % 2

...

while fresh:
    is_newly_rotten = False
    for _ in range(len(q)):
        r, c = q.popleft()
        for x, y in move:
            next_r, next_c = r+x, c+y
            if is_valid_coord(next_r, next_c) and grid[next_r][next_c] == 1:
                grid[next_r][next_c] = 2
                fresh -= 1
                is_newly_rotten = True
                q.append([next_r, next_c])
    if not is_newly_rotten:
        return -1
```

이런 문제가 생기지 않도록 오렌지가 상하기 전에 빨리 먹어치우는 것이 좋겠다😋

## 🙄오늘의 시간낭비

사소하고 엄청난 과오를 저지르는 바람에 TLE에 빠져 고통받았다.

BFS 돌리는 부분이 문제일 가능성이 높은데 원인을 알 수가 없어 while문을 유한 for문으로 바꾸고, 지정된 출력 타입이 int인 점을 이용하여 큐의 길이를 출력해보았다.

그 결과, 루프를 많이 돌릴수록 큐에 점점 더 많은 좌표가 쌓이는 것을 알 수 있었다.

시간이 지날수록 싱싱한 오렌지의 수가 줄어드니 큐가 계속 커질 이유가 없는데 왜 이러한 일이 발생할까?

큐에 들어가면 안 될 것들이 쌓이고 있는 것 같다.

```python
while fresh:
...
    if is_valid_coord(next_r, next_c) and grid[next_r][next_c] == 1:
        grid[next_r][next_c] == 2
```

확인해 보니 =를 하나 더 쓰는 바람에 싱싱한 오렌지(1)를 상한 오렌지(2)로 바꾸는 과정이 실제로는 동작하지 않고 있었다.

실수는 사소하지만 정말 찾기 힘들었다🤮