### PR TITLE
[5주차] yyj-Leetcode-918

### DIFF
--- a/Leetcode/918/yyj.py
+++ b/Leetcode/918/yyj.py
@@ -1,0 +1,19 @@
+class Solution:
+    def maxSubarraySumCircular(self, nums: List[int]) -> int:
+        n = len(nums)
+        dp_contiguous = [0 for _ in range(n)]
+        max_contiguous = -sys.maxsize
+        
+        dp_excluding_both_ends = [0 for _ in range(n)]
+        min_excluding_both_ends = sys.maxsize
+        
+        for i in range(n):
+            dp_contiguous[i] = max(nums[i]+dp_contiguous[i-1], nums[i])
+            max_contiguous = max(max_contiguous, dp_contiguous[i])
+            
+        for i in range(1, n-1):
+            dp_excluding_both_ends[i] = min(nums[i]+dp_excluding_both_ends[i-1], nums[i])
+            min_excluding_both_ends = min(min_excluding_both_ends, dp_excluding_both_ends[i])
+        max_splited = sum(nums) - min_excluding_both_ends
+        
+        return max(max_contiguous, max_splited)


### PR DESCRIPTION
## 문제

[https://leetcode.com/problems/maximum-sum-circular-subarray/](https://leetcode.com/problems/maximum-sum-circular-subarray/)

## 개요

- 하나 이상의 원소가 존재하는 int형 배열이 주어진다(nums).
- 주어진 배열을 Circular array로 보고 최대 부분합을 구하여 리턴한다.

## 초기 설계

- 최대 부분합은 다음 두 가지 경우 중에서 나올 수 있다.
  - 1 주어진 배열 안에서 연속된 경우
  - 2 주어진 배열의 양 끝값을 포함하며 두 구간으로 분할된 경우
- 1), 2)는 서로 중복이 없고 모든 케이스를 커버하므로, 각각 구하여 둘 중 최댓값을 리턴한다.

## 어려움을 겪은 내용

### 1. ‘2) 주어진 배열의 양 끝값을 포함하며 두 구간으로 분할된 경우’ 구하기

‘1) 주어진 배열 안에서 연속된 경우’는 i번째 원소를 끝값으로 가지는 최대 부분합을 배열(dp_contiguous[])에 저장하면서 최대값을 갱신(max_contiguous)하면 쉽게 구할 수 있다.

그러나 ‘2) 주어진 배열의 양 끝값을 포함하며 두 구간으로 분할된 경우’를 같은 방식으로 풀려고 하면 가변 구간이 2개가 되므로 다루기가 쉽지 않았다.

## 해결 방법

### 1. 구할 대상이 아닌 부분 구하기

<html>
<body>
<table border = 0>
<tr>
<td>Maximum Sum</td>
<td><span style="background-color="fffda9">Minimum Sum(구할 값)</span></td>
<td>Maximum Sum</td>
</tr>
</table>
</body>
</html>

2)의 경우를 다시 살펴보면 가변 구간이 하나이면서 최대 부분합 구간과 겹치지 않고, 최대 부분합 구간과 합쳤을 때 전체 배열이 되는 구간이 있다(가운데).

해당 구간의 합이 최소가 되도록 하면 양 끝 구간의 합이 최대가 될 것이다.

이 때, 가운데 구간이 배열 양 끝값 중 하나라도 포함하면 1)의 케이스가 되므로 최소합을 구하는 범위에서 배열의 양 끝값은 제외한다.

이제 1)의 경우와 똑같은 로직으로 풀 수 있게 되었다.

```python
dp_excluding_both_ends = [0 for _ in range(n)]
min_excluding_both_ends = sys.maxsize

# 주어진 배열 안에서 연속된 구간 최대합(max_contiguous)을 구한다
...

# 주어진 배열의 양 끝값을 제외한 구간 최소합을 구하고(min_excluding_both_ends),
# 이를 배열 전체합에서 뺀다(max_splited)
for i in range(**1, n-1**):
    dp_excluding_both_ends[i] = min(nums[i]+dp_excluding_both_ends[i-1], nums[i])
    min_excluding_both_ends = min(min_excluding_both_ends, dp_excluding_both_ends[i])
max_splited = sum(nums) - min_excluding_both_ends

return max(max_contiguous, max_splited)
```

노란색 구간의 합이 최소일 때 2) 케이스의 최대값이 나온다는 확신을 갖는 데 시간이 꽤 걸렸다.

빠르게 검증할 수 있는 방법을 알고 싶다🤪