### PR TITLE
[6주차] yyj-Leetcode-1155

### DIFF
--- a/Leetcode/1155/yyj.py
+++ b/Leetcode/1155/yyj.py
@@ -1,0 +1,21 @@
+class Solution:
+    def numRollsToTarget(self, n: int, k: int, target: int) -> int:
+        mem = {}
+        
+        def dp(remaining_dice: int, remaining_sum: int) -> int:
+            if remaining_dice == 0:
+                return 1 if remaining_sum == 0 else 0
+            elif remaining_sum <= 0:
+                return 0
+            
+            if (remaining_dice, remaining_sum) in mem:
+                return mem[(remaining_dice, remaining_sum)]
+            
+            res = 0
+            for face in range(1, k+1):
+                res += dp(remaining_dice-1, remaining_sum-face)
+            mem[(remaining_dice, remaining_sum)] = res
+            return res
+        
+        modulo = pow(10, 9) + 7
+        return dp(n, target) % modulo


### PR DESCRIPTION
## 문제

[https://leetcode.com/problems/number-of-dice-rolls-with-target-sum/](https://leetcode.com/problems/number-of-dice-rolls-with-target-sum/)

## 개요

- 입력으로 주사위의 개수(n), 각 주사위 면의 개수(k), 주사위 값의 목표총합(target)이 주어진다.
    - 주사위 면의 값 : 1~k
- 주사위 n개를 모두 굴려 나온 값의 합이 target이 되는 경우의 수를 (10^9 + 7)로 나눈 나머지를 리턴한다.

## 초기 설계

- dp(d, target) : 면의 개수가 k인 주사위 n개를 굴려서 목표총합(target)을 얻을 수 있는 경우의 수
- Recurrence relation
    - dp(n, target) = dp(n-1, target-1) + dp(n-1, target-2) + ... + dp(n-1, target-k)
    - base case : n == 0(굴릴 주사위가 더 이상 남지 않았을 때)
        - target == 0이면 주사위를 모두 소모하여 목표총합을 얻은 상태이므로 1을, 그 외의 경우 0을 리턴한다.

## 어려움을 겪은 내용

### 1. TLE

처음 작성한 코드는 아래와 같다.

샘플 테스트케이스는 통과하였으나, 제출 시 범위 상한(n=30, k=30)의 테스트케이스가 등장하여 TLE를 받았다.

```python
class Solution:
    def numRollsToTarget(self, n: int, k: int, target: int) -> int:
        # n: #dice, k: #face
        def dp(remaining_dice: int, remaining_sum: int) -> int:
            if remaining_dice == 0:
                return 1 if remaining_sum == 0 else 0
            
            res = 0
            for face in range(1, k+1):
                res += dp(remaining_dice-1, remaining_sum-face)
            return res
        
        modulo = pow(10, 9) + 7
        return dp(n, target) % modulo
```

## 해결 방법

### 1. Memoization

중복된 연산을 줄여 효율성을 높이고자 이미 계산한 값은 별도로 저장해두는 편이 좋겠다.

딕셔너리 타입 mem{}에 dp 함수를 재귀호출할 때마다 결과값을 저장하게 하고, 이미 계산되어 저장된 값이면 mem{}에서 찾아 쓰도록 하였다.

key는 튜플 타입으로, (남은 주사위의 수, 앞으로 얻어야 할 목표 총합)으로 하였다.

```python
class Solution:
    def numRollsToTarget(self, n: int, k: int, target: int) -> int:
        # const - n: #dice, k: #face
        **mem = {}**
        
        def dp(remaining_dice: int, remaining_sum: int) -> int:
            if remaining_dice == 0:
                return 1 if remaining_sum == 0 else 0
            
            if (remaining_dice, remaining_sum) in mem:
                return mem[(remaining_dice, remaining_sum)]
            
            res = 0
            for face in range(1, k+1):
                res += dp(remaining_dice-1, remaining_sum-face)
            mem[(remaining_dice, remaining_sum)] = res
            return res
        
        modulo = pow(10, 9) + 7
        return dp(n, target) % modulo
```

아래와 같이 cache 데코레이터를 사용할 수도 있지만 Memoizaion과 Bottom-up 방식도 사용할 수 있도록 연습하는 것이 좋겠다.

```python
class Solution:
    def numRollsToTarget(self, n: int, k: int, target: int) -> int:
        @lru_cache(None)
        def dp(remaining_dice: int, remaining_sum: int) -> int:
...
```

**<Additional Approach - Backtracking>**

지금까지 만든 dp 함수는 굴릴 주사위가 하나도 남지 않을 때까지 탐색을 계속한다(depth : n).

하지만 주사위 면의 값이 항상 양수이고, 현재 목표총합에서 주사위 면의 값을 빼서 다음 목표총합을 구한다는 점을 잘 생각해보자.

탐색 중 굴릴 주사위가 남았음에도 불구하고(remaining_dice > 0) 남은 목표총합이 0 이하(remaining_sum ≤ 0)가 된 경우는 계속 탐색할 필요가 없다..

재귀호출을 하기 전 위와 같은 상태인지를 확인하여 해당할 경우 0을 리턴함으로써 탐색을 중단하도록 하자.

```python
def dp(remaining_dice: int, remaining_sum: int) -> int:
    if remaining_dice == 0:
        return 1 if remaining_sum == 0 else 0
    elif remaining_sum <= 0:
        return 0
    #...recursive call below...#
```

Leetcode 채점 결과, 2회 실행시간 평균 616ms(608ms, 624ms)로 이전 코드의 2회 실행시간 평균 834.5ms(835ms, 834ms)에 비해 평균 26% 정도 개선되었다.

cache 데코레이터 + Backtracking 조합을 사용할 경우 2회 실행시간 평균이 406.5ms(335ms, 478ms)까지 내려갔다.