### PR TITLE
[7주차] YGG-baekjoon-1018

### DIFF
--- a/baekjoon/1018/YGG.py
+++ b/baekjoon/1018/YGG.py
@@ -1,17 +1,15 @@
 def paint_area(m: int, n: int, arr) -> int:
     count = 0
-    start = 0 + 0
     char = arr[0][0]
     for i in range(8):
         for j in range(8):
-            if ((i + j) % 2 == start % 2) ^ (arr[i][j] == char):
+            if ((i + j) % 2 == 0) ^ (arr[i][j] == char):
                 count += 1
     prev_val = count
     ans = min(count, 64 - count)
 
     for y in range(0, len(arr) - 8):
         # (0~n-8, 0~7) -> (8~n-1, 0~7)
-        start = y + 0
         for x in range(8):
             if ((y + x) % 2 == 0) ^ (arr[y][x] == char):
                 count -= 1
@@ -22,7 +20,6 @@ def paint_area(m: int, n: int, arr) -> int:
     for j in range(0, len(arr[0]) - 8):
         count = prev_val
         # (0~7, j-8) -> (0~7, j)
-        start = 0 + j+1
         for y in range(8):
             if ((y + j) % 2 == 0) ^ (arr[y][j] == char):
                 count -= 1
@@ -33,7 +30,6 @@ def paint_area(m: int, n: int, arr) -> int:
 
         j += 1
         for y in range(0, len(arr) - 8):
-            start = y + j
             # (0~n-8, j~j+7) -> (8~n-1, j~j+7)
             for x in range(8):
                 if ((y + j+x) % 2 == 0) ^ (arr[y][j+x] == char):
@@ -46,8 +42,8 @@ def paint_area(m: int, n: int, arr) -> int:
 
 
 a, b = map(int, input().split())
-arr = []
+c = []
 for k in range(a):
-    arr.append(input())
+    c.append(input())
 
-print(paint_area(a, b, arr))
+print(paint_area(a, b, c))

--- a/baekjoon/1018/YGG.py
+++ b/baekjoon/1018/YGG.py
@@ -1,0 +1,53 @@
+def paint_area(m: int, n: int, arr) -> int:
+    count = 0
+    start = 0 + 0
+    char = arr[0][0]
+    for i in range(8):
+        for j in range(8):
+            if ((i + j) % 2 == start % 2) ^ (arr[i][j] == char):
+                count += 1
+    prev_val = count
+    ans = min(count, 64 - count)
+
+    for y in range(0, len(arr) - 8):
+        # (0~n-8, 0~7) -> (8~n-1, 0~7)
+        start = y + 0
+        for x in range(8):
+            if ((y + x) % 2 == 0) ^ (arr[y][x] == char):
+                count -= 1
+            if ((y+8 + x) % 2 == 0) ^ (arr[y+8][x] == char):
+                count += 1
+        ans = min(ans, count, 64 - count)
+
+    for j in range(0, len(arr[0]) - 8):
+        count = prev_val
+        # (0~7, j-8) -> (0~7, j)
+        start = 0 + j+1
+        for y in range(8):
+            if ((y + j) % 2 == 0) ^ (arr[y][j] == char):
+                count -= 1
+            if ((y + j+8) % 2 == 0) ^ (arr[y][j+8] == char):
+                count += 1
+        prev_val = count
+        ans = min(ans, count, 64 - count)
+
+        j += 1
+        for y in range(0, len(arr) - 8):
+            start = y + j
+            # (0~n-8, j~j+7) -> (8~n-1, j~j+7)
+            for x in range(8):
+                if ((y + j+x) % 2 == 0) ^ (arr[y][j+x] == char):
+                    count -= 1
+                if ((y+8 + j+x) % 2 == 0) ^ (arr[y+8][j+x] == char):
+                    count += 1
+            ans = min(ans, count, 64 - count)
+
+    return ans
+
+
+a, b = map(int, input().split())
+arr = []
+for k in range(a):
+    arr.append(input())
+
+print(paint_area(a, b, arr))


### PR DESCRIPTION
## 문제
https://www.acmicpc.net/problem/1018
검은색 또는 흰색 정사각형 타일이 길이가 8~50인 m x n 크기로 구성되어 있을 때
이를 체커보드 (체스판 무늬) 로 만들기 위해 칠해야 하는 최소 타일 수를 구하는 문제

## 어려움을 겪은 내용
문제가 복잡하지는 않았는데,
구현과 최적화를 같이 진행하다가 산식을 계속 혼동하여 시간 지체됨
(memoization 추가하면서 마지막 줄 탐색을 빠뜨린다던지, ans에 min 값 비교로 변경하면서 빼먹은 줄이 있다던지..)

처음에는 시작타일 기준으로 맞지 않는 개수를 셌음
하지만 memoization 으로 구현하다보니 시작타일이 달라지는 경우가 생겨 고민하게 됨

<img width="402" alt="image" src="https://user-images.githubusercontent.com/16753880/160889544-e5de7fe1-0aaa-4a9b-a7ba-bce0592886f8.png">
→ 색이 2개 뿐이라 둘 중 아무거나 계산하고 min(값, 64 - 값)을 취해주면 됨!

## 해결 방법
 + brute force : 모든 8x8 경우의 수를 조사했음
 + memoization : 항상 새로 계산하는 것이 아닌 이전 위치부터 한 줄씩 순회하면서 개수 업데이트
<img width="218" alt="image" src="https://user-images.githubusercontent.com/16753880/160888007-ebfaa8f7-2dc4-41c5-ae91-2edbcaf2cf73.png">

 1. [0, 0] ~ [7, 7] 의 결과를 저장함 (prev_val)
 1. 아랫쪽 행을 하나씩 순회하면서 count에서 첫 번째 행 count를 빼고 마지막 행 count를 추가
 
 

<img width="218" alt="image" src="https://user-images.githubusercontent.com/16753880/160888028-2960ec5a-0dc0-4eda-9c32-65a9167093cb.png">

 1. 0~7열에 대해 계산이 끝날 경우 저장해둔 값을 불러오고
 3. 첫 번째 열 count를 빼고 다음 열 0~7행 count를 추가
 4. 1.부터 반복

## 시도해볼 것
구간합
https://chanhuiseok.github.io/posts/baek-19/