### PR TITLE
[7주차] SUB-baekjoon-1043

### DIFF
--- a/baekjoon/1043/SUB.py
+++ b/baekjoon/1043/SUB.py
@@ -1,0 +1,31 @@
+n, m = map(int, list(input().split()))
+
+truth = set()
+ans = 0
+
+temp = input().split()
+
+for i in range(1, int(temp[0])+1):
+    truth.add(temp[i])
+#print(truth)
+party_member = []
+
+for i in range(m):
+    set_temp = set()
+    temp = input().split()
+    for j in range(1, int(temp[0])+1):
+        set_temp.add(temp[j])
+    party_member.append(set_temp)
+#print(party_member)
+cnt = 0
+while cnt < m:
+    for i in range(m):
+        if len(truth & party_member[i]) > 0:
+            truth|=party_member[i]
+    cnt+=1
+#print(truth)
+for i in range(m):
+    if len(truth & party_member[i]) == 0:
+        ans+=1
+
+print(ans)


### PR DESCRIPTION
## 문제
<https://www.acmicpc.net/problem/1043>
## 어려움을 겪은 내용
처음에는 단순히 진실을 아는 사람들의 집합을 만들고, 파티에 참석하는 사람의 번호를 입력 받으면서 해당 파티에 진실을 아는 사람이 없는 경우를 세어주었다. 
하지만 아래와 같이 진실을 아는 집합이 1, 2일 경우, 파티 B에서 3은 이미 진실을 얘기한 것을 들었으므로, C파티에서 거짓말을 할 경우 3은 처음 진실을 아는 집단에 속하지는 않았지만 거짓말과 사실 둘 다 듣게 된다.
![image](https://user-images.githubusercontent.com/31717041/160954993-5bc5e222-4bd7-4558-88a9-169c1b9a9521.png)

## 해결 방법
먼저 모든 파티에 대한 참석자를 다 입력받은 뒤, 파티를 전체적으로 한번 돌면서 진실을 아는 사람과 같이 참석한 사람도 진실을 아는 집합에 포함해 주었다. 그 다음, 다시 모든 파티를 확인하여 진실을 아는 사람이 없는 파티에서만 거짓말을 하도록 하였다. 

![image](https://user-images.githubusercontent.com/31717041/160955560-886e6ad7-527d-44ee-b18d-9af2914331f9.png)
해당 방법대로 수행한 뒤, 진실을 아는 집단은 위 그림처럼 (1, 2, 3)이 되므로 어떠한 파티에서도 진실을 말할 수 없으므로 답은 0이 된다.
하지만 이 방법으로는 아래와 같은 경우는 해결되지 않았다.

![image](https://user-images.githubusercontent.com/31717041/160956130-62e914d7-faa8-41fe-9308-0be3ff08373e.png)
기존 방법대로면 (1, 2, 3)이 없는 파티 D와 파티 E에서는 거짓말을 해도 되는 것으로 처리되는데, 파티가 3개였을 때와 동일하게 4도 파티 C에서 진실을 듣고 D에서는 거짓말을 듣는 모순이 생겨버린다. 따라서 파티 전체를 순회하면서 진실을 아는 사람을 포함 시키는 동작을 파티의 개수만큼 수행해줘야 정확한 정답을 얻을 수 있다