### PR TITLE
[7주차] yyj-Leetcode-37

### DIFF
--- a/Leetcode/37/yyj.py
+++ b/Leetcode/37/yyj.py
@@ -1,0 +1,62 @@
+class Solution:
+    def solveSudoku(self, board: List[List[str]]) -> None:
+        """
+        Do not return anything, modify board in-place instead.
+        """
+        
+        def box_idx(r: int, c: int) -> int:
+            return ((r // 3)) * 3 + c // 3
+        
+        def is_placeable(r: int, c: int, d: int) -> bool:
+            return (d not in rows[r]) and (d not in cols[c]) and (d not in boxes[box_idx(r, c)])
+        
+        def place_number(r: int, c: int, d: int) -> None:
+            rows[r][d] += 1
+            cols[c][d] += 1
+            boxes[box_idx(r, c)][d] += 1
+            board[r][c] = str(d)
+        
+        def move_next_cells(r: int, c: int) -> None:
+            if r == n-1 and c == n-1:
+                nonlocal is_solved
+                is_solved = True
+            else:
+                if c == n-1:
+                    backtrack(r+1, 0)
+                else:
+                    backtrack(r, c+1)
+                
+        def remove_number(r: int, c: int, d: int) -> None:
+            del rows[r][d]
+            del cols[c][d]
+            del boxes[box_idx(r, c)][d]
+            board[r][c] = '.'
+        
+        
+        def backtrack(r: int, c: int) -> None:
+            if board[r][c] == '.':
+                for d in range(1, 10):
+                    if is_placeable(r, c, d):
+                        place_number(r, c, d)
+                        move_next_cells(r, c)
+                        if not is_solved:
+                            remove_number(r, c, d)
+            else:
+                move_next_cells(r, c)
+        
+        
+        n = len(board)
+        
+        rows = [collections.defaultdict(int) for _ in range(n)]
+        cols = [collections.defaultdict(int) for _ in range(n)]
+        boxes = [collections.defaultdict(int) for _ in range(n)]
+        
+        is_solved = False
+        
+        for r in range(n):
+            for c in range(n):
+                if board[r][c] != '.':
+                    d = int(board[r][c])
+                    place_number(r, c, d)
+        
+        backtrack(0, 0)


### PR DESCRIPTION
## 문제

[https://leetcode.com/problems/sudoku-solver/](https://leetcode.com/problems/sudoku-solver/)

## 개요

- 일부 칸만 채워져있는 스도쿠 퍼즐을 아래 규칙에 따라 완성한다(리턴 없이 주어진 퍼즐에 작성).
    - 퍼즐판은 총 9 * 9인 정사각형이며, 이 퍼즐판은 가로 3개, 세로 3개의 3 * 3 크기 정사각형 구역 총 9개로 이루어진다.
    - 각 행/각 열에는 1~9까지의 숫자를 단 한번씩만 쓸 수 있다.
    - 3 * 3 크기 정사각형 구역에는 1~9까지의 숫자를 단 한번씩만 쓸 수 있다.

## 초기 설계

- 각 칸을 기준으로 재귀호출(recursion), 각 빈칸마다 1~9까지의 후보 d를 시도한다(iteration within recursion). - *(backtrack)*
    - 숫자 d를 현재 칸 (r, c)에 쓸 수 있다면*(is_placeable)*, 쓴 사실을 기록한다*(place_number)*.
        - 가능한 조건 : 같은 열에 d가 없다 & 같은 행에 d가 없다 & (r, c)가 속한 3 * 3 크기 정사각형 구역에 d가 없다
            - 3 * 3 크기 정사각형 구역 구하기*(box_idx)* : ((r // 3)) * 3 + c // 3
        - 위 조건을 확인하려면 d의 존재 여부를 자주 찾게 되므로 검색이 빠른 dictionary 자료구조를 사용한다.  초기값이 자동으로 설정되는 defaultdict을 사용하면 연산이 용이하겠다.
    - 위 상태를 가지고 다음 칸을 재귀호출한다. 각 행의 맨 끝 칸일 때와 그렇지 않을 때 다르게 처리해야 함을 유의하자*(move_next_cells)*.
    - 만약 맨 끝칸까지 숫자를 채울 수 없다면, d를 (r, c)에 쓴 상태로는 정답을 낼 수 없다는 뜻이 된다. 쓰기 전 상태로 돌린다*(remove_number)*.

## 어려움을 겪은 내용 & 해결 방법

### D1. 빈칸이 아닌 경우의 처리

처음 작성한 backtrack 함수는 아래와 같다.

샘플 테스트케이스를 실행했을 때 출력값에 아무런 변화가 일어나지 않았다.

```python
class Solution:
    def solveSudoku(self, board: List[List[str]]) -> None:
        def backtrack(r: int, c: int) -> None:
            if board[r][c] == '.':
                # iterate all possible candidates(d : 1~9)			
                for d in range(1, 10):

                    # check if d is placeable at (r, c)
                    if is_placeable(r, c, d):

                        # if placeable, place it
                        place_number(r, c, d)

                        # given d at (r, c), explore further
                        move_next_cells(r, c)

                        # if sudoku cannot be solved with d at (r, c),
                        # remove d(backtrack)
                        remove_number(r, c, d)

        backtrack(0, 0)
```

### S1. 빈칸이 아닌 경우의 처리

backtrack 함수의 구조와 호출 상태를 살펴보자.

backtrack(r, c)를 호출하면 board[r][c]가 빈칸일 때만 재귀호출 및 백트래킹이 일어나고, board[r][c]가 빈칸이 아닐 때는 아무 일도 일어나지 않고 더 이상의 함수 호출도 없다.

backtrack 함수를 호출할 때 입력한 초기값이 (0, 0)이므로, board[0][0]이 빈칸이 아니면 아무 변화 없이 함수가 종료될 것이다.

빈칸이 아닌 경우에도 처리를 할 수 있도록 backtrack 함수를 수정해 보자.

만약 현재 칸에 이미 숫자가 있다면, 현재 칸의 상태는 변화시킬 필요 없이 다음 칸들에 대한 처리(move_next_cells)를 하게 하면 된다.

```python
class Solution:
    def solveSudoku(self, board: List[List[str]]) -> None:
        def backtrack(r: int, c: int) -> None:
            if board[r][c] == '.':
                # do placing, recursive call, and removing
								...

            # NOTICE; if a number is already written at (r, c),
            # just explore further
            else:
                move_next_cells(r, c)
```

---

### D2. 리턴값이 없는 경우의 정답 발견 여부 판정

리턴값이 있는 경우 정답 조건에 맞으면 리턴으로 처리하면 되는데, 주어진 solveSudoku 함수는 리턴값이 없어서 같은 방법을 쓸 수 없었다.

정답을 하나만 발견하면 바로 종료하는 문제이므로, backtrack 함수에 정답 조건 충족 여부를 추가하기보다는 좀 더 깔끔하게 처리할 수 있는 방법을 찾고 싶었다.

### S2. nonlocal keyword

python에는 nonlocal keyword가 있는데, 키워드가 사용된 위치에서 바로 한 단계 바깥쪽에 위치한 변수와 바인딩할 수 있게 해주는 키워드이다(전역변수 제외).

solveSudoku 함수에서 backtrack 함수를 호출하기 전 단계에 bool 타입 변수 is_solved(초기값 False)를 선언하고, solveSudoku 함수 내에 선언된 move_next_cells 함수에서 종료 조건에 도달할 때 해당 변수 값을 True로 변경하게 하였다.

그리고 backtrack 함수에서 재귀호출 수행 후 is_solved 변수값을 검사하여 False일 때만 백트래킹(board에 적어둔 숫자 지우기)을 하도록 하였다.

종료 조건에 도달하여 is_solved가 True가 되면 백트래킹이 일어나지 않으므로 board에 정답이 입력된 상태가 유지될 것이다.

```python
class Solution:
    def solveSudoku(self, board: List[List[str]]) -> None:
        ...
        def move_next_cells(r: int, c: int) -> None:
            if r == n-1 and c == n-1:
                nonlocal is_solved
                is_solved = True
            else:
                if c == n-1:
                    backtrack(r+1, 0)
                else:
                    backtrack(r, c+1)

        def backtrack(r: int, c: int) -> None:
            if board[r][c] == '.':
                for d in range(1, 10):
                    if is_placeable(r, c, d):
                        place_number(r, c, d)
                        move_next_cells(r, c)
                        if not is_solved:
                            remove_number(r, c, d)
            
            else:
                move_next_cells(r, c)

        is_solved = False

        backtrack(0, 0)
```

~~IDE 쓰고 싶은 문제는 처음이다~~ 🤪