### PR TITLE
[8주차] 김준근-baekjoon-2166

### DIFF
--- a/baekjoon/2166/김준근.py
+++ b/baekjoon/2166/김준근.py
@@ -1,0 +1,21 @@
+from sys import stdin
+
+point_count = int(stdin.readline())
+points = [tuple(map(int, stdin.readline().split())) for _ in range(point_count)]
+
+point0 = points[0]
+result = 0.0
+
+
+def get_triangle_area(point0, point1, point2):
+    a = (point1[0] - point0[0], point1[1] - point0[1])
+    b = (point2[0] - point0[0], point2[1] - point0[1])
+    return (a[0] * b[1] - a[1] * b[0]) * 0.5
+
+
+for i in range(point_count - 1):
+    point1 = points[i]
+    point2 = points[i + 1]
+    result += get_triangle_area(point0, point1, point2)
+
+print(round(abs(result), 1))


### PR DESCRIPTION
## 문제

https://www.acmicpc.net/problem/2166

## 어려움을 겪은 내용

1. 세 점이 주어진 삼각형의 넓이 구하기
2. 다각형이 오목한 경우의 처리

## 해결 방법

여러개의 삼각형으로 나누어서 면적을 합하면 되겠다고는 빠르게 생각해냈다. 하지만 아래와 같은 문제가 있었다.

### 좌표 3개가 주어졌을 때, 삼각형 면적 구하기

벡터의 외적을 사용할 생각을 전혀못했다. 두 벡터 a, b가 있을 때 두 벡터를 외적한 벡터의 크기는 |a||b|sinθ 라는 것을 완전히 잊고 있었다.

### 오목 다각형의 경우

삼각형의 면적을 단순히 모두 더해서 반환하면 될거라고 생각했다. 하지만 이는 볼록 다각형의 경우에만 해당한다. 오목 다각형일 경우를 생각해줘야된다.

이 경우를 해결하기 위해서는 두 가지를 생각하면된다.

1. 세 점을 선택했을 때 나오는 모든 면적이 볼록하면 더하고, 오목하면 빼주면된다.
2. 오목한 부분에서는 외적의 방향이 반대로 나타난다.

![image](https://user-images.githubusercontent.com/4648244/161985491-9fc60a90-ff23-4b6e-90ec-ffe935f38746.png)
