### PR TITLE
[9주차] yyj-Leetcode-2218

### DIFF
--- a/Leetcode/2218/yyj.py
+++ b/Leetcode/2218/yyj.py
@@ -1,0 +1,17 @@
+class Solution:
+    def maxValueOfCoins(self, piles: List[List[int]], k: int) -> int:
+        @lru_cache(None)
+        def pick(pile_idx: int, need_to_pick: int) -> int:
+            if pile_idx == n or need_to_pick == 0:
+                return 0
+            
+            res = pick(pile_idx+1, need_to_pick)    # set default value: pick nothing in pile[pile_idx]
+            curr_total = 0
+            for j in range(min(len(piles[pile_idx]), need_to_pick)):
+                curr_total += piles[pile_idx][j]
+                res = max(res, curr_total + pick(pile_idx+1, need_to_pick-j-1))
+            return res
+        
+        n = len(piles)
+        
+        return pick(0, k)


### PR DESCRIPTION
## 문제

[https://leetcode.com/problems/maximum-value-of-k-coins-from-piles/](https://leetcode.com/problems/maximum-value-of-k-coins-from-piles/)

## 개요

- 정수 배열 n개로 구성된 배열 piles가 주어진다.
    - 각 정수 배열은 한 줄로 쌓여있는 코인 무더기를 나타낸다.
    - 각 정수 배열의 원소는 코인의 금액을 나타내며, 인덱스가 작을수록 위에 놓인 코인이다.
- 한 번에 코인 1개씩을 아무 무더기에서나 가져올 수 있다. 이 때, 가장 위에 놓인 코인만 취할 수 있으며 가져온 코인은 코인 무더기에서 사라진다.
- 코인을 k번 가져올 때 얻을 수 있는 최대 금액을 리턴한다.

## 초기 설계

- 탐욕법으로 문제를 푸는 것은 불가능하다. `piles = [[100],[100],[100],[100],[100],[100],[1,1,1,1,1,1,700]], k = 7`일 때, 탐욕법을 이용하면 601이 되겠지만 실제 답은 706이다. 맨 끝 배열에서만 코인(숫자)을 꺼내면 된다.
- dp(k) = dp(k-1) + (코인 k-1개를 꺼낸 이후 각 무더기 최상단 코인의 최대 금액)
- 찾고자 하는 답은 총합의 최대치이고 각 코인의 금액은 항상 불변이므로 코인을 꺼내는 순서는 관계없다. 이 성질을 이용하여 탐색할 가짓수를 줄일 수 있다.

## 어려움을 겪은 내용 & 해결 방법

### D1. 순서의 영향을 받지 않는 설계

코인을 꺼내는 순서를 계산할 필요가 없다는 점은 인식하였으나, 실제로 이 점을 설계에 어떻게 반영해야 할지 고민이 되었다.

최초 설계식을 dp(k) = dp(k-1) + (코인 k-1개를 꺼낸 이후 각 무더기 최상단 코인의 최대 금액)로 했는데, 이렇게 생각할 경우 코인을 꺼내는 순서를 반영하는 것과 다름없었다. 

순서를 반영하는 방식으로 작성할 경우 탐색할 가짓수가 훨씬 많아지는 점이 가장 큰 문제였다. 케싱에 있어서도, pick 함의 인자로 값이 가변인 list를 받기 때문에 데코레이터 사용이 불가능하고, 자체 해시맵을 만들기도 까다롭게 되어 개선이 필요하다고 생각하였다.

(이 코드는 실랭하면 TLE를 받으며, 시간 안에 실행 가능한 테스트케이스의 수도 매우 적다.)

```python
class Solution:
    def maxValueOfCoins(self, piles: List[List[int]], k: int) -> int:
        def pick(picked_coins: int, state: List[int], curr_total: int) -> int:
            if picked_coins == k:
                return curr_total
            
            res = 0
            for i in range(n_piles):
                new_state = state[:]
                if new_state[i] < len(piles[i]) - 1:
                    new_state[i] += 1
                    res = max(res, pick(picked_coins+1, new_state, curr_total+piles[i][new_state[i]]))
            return res
        
        n_piles = len(piles)
        state = [-1 for _ in range(n_piles)]
        
        return pick(0, state, 0)
```

### S1. 설계식 변경

상태 이전의 단위를 ‘코인 하나 꺼내기’가 아닌 ‘무더기 하나에서 꺼낼 만큼 고르기’로 바꾸어 생각해 보자.

이번 차례에 코인을 고를 코인 무더기의 번호를 i, 앞으로 골라야 할 코인의 수를 need_to_pick으로 한다.

한 무더기에서 고를 수 있는 코인 수의 최솟값은 0이다.

최댓값의 경우, 일단 무더기에 있는 코인 전체를 고르는 경우를 생각해볼 수 있다. 주의할 점은 고른 코인의 누적 수량이 처음에 주어진 값(k)을 초과해서는 안 된다는 것이다. 따라서, 앞으로 골라야 할 코인의 수(need_to_pick)를 초과하여 고를 수는 없다. 이를 정리하면 한 무더기에서 고를 수 있는 코인 수의 최댓값은 min(piles[pile_idx], need_to_pick)이 된다.

dp(i, need_to_pick)을 정리하면 아래와 같다.

0 ≤ j < min(piles[i], need_to_pick)에 대하여, (i번 무더기에서 고른 코인의 총합) + dp(i-1, need_to_pick+(j+1)) 중 최댓값

```python
class Solution:
    def maxValueOfCoins(self, piles: List[List[int]], k: int) -> int:
        @lru_cache(None)
        def pick(pile_idx: int, need_to_pick: int) -> int:
            if pile_idx == n or need_to_pick == 0:
                return 0
            
            res = 0
            curr_total = 0
            for j in range(min(len(piles[pile_idx]), need_to_pick)):
                curr_total += piles[pile_idx][j]
                res = max(res, curr_total + pick(pile_idx+1, need_to_pick-(j+1)))
            return res
        
        n = len(piles)
        
        return pick(0, k)
```

---

### D2. 모든 경우 탐색하기

piles = [[500], [100], [100], [100], [100], [100], [901,1,1,1,1,1,700]], k = 4로 테스트한 결과, 답이 800으로 나왔다(실제 정답은 1601).

901을 고르지 못하는 것 같다.

### S2. 아무것도 고르지 않는 경우 처리

for문 내부를 검토해 보자. for문은 pile_idx번째 코인 무더기에서 [0번째 코인], [0번째, 1번째 코인], ... [0번째, 1번째, ... , N번째 코인]을 고른다(0-indexed).

아무것도 고르지 않고 다음 코인 무더기로 넘어간 경우는 포함되지 않음을 알 수 있다.  이를 res의 기본값으로 설정해 준다.

```python
class Solution:
    def maxValueOfCoins(self, piles: List[List[int]], k: int) -> int:
        @lru_cache(None)
        def pick(pile_idx: int, need_to_pick: int) -> int:
            if pile_idx == n or need_to_pick == 0:
                return 0
            
            # set default value: pick nothing in pile[pile_idx]
            res = pick(pile_idx+1, need_to_pick)
            curr_total = 0
            for j in range(min(len(piles[pile_idx]), need_to_pick)):
                curr_total += piles[pile_idx][j]
                res = max(res, curr_total + pick(pile_idx+1, need_to_pick-(j+1)))
            return res
        
        n = len(piles)
        
        return pick(0, k)
```