### PR TITLE
[9주차] ygg-Leetcode-76

### DIFF
--- a/Leetcode/76/ygg.py
+++ b/Leetcode/76/ygg.py
@@ -1,0 +1,55 @@
+def minWindow(s: str, t: str) -> str:
+    if len(s) < len(t):
+        return ""
+    elif len(t) == 1:
+        if s.find(t) >= 0:
+            return t
+        else:
+            return ""
+
+    l = len(t)
+    T = {}
+    for c in t:
+        if c in T:
+            T[c] += 1
+        else:
+            T[c] = 1
+
+    a = 0
+    pos = []
+    ans = (-1, 100000)
+    for i in range(len(s)):
+        if s[i] in T:
+            if T[s[i]] > 0:
+                pos.append(i)
+                T[s[i]] -= 1
+                a += 1
+            else:
+                if s[i] == s[pos[0]]:
+                    pos.pop(0)
+                    while pos and T[s[pos[0]]] < 0:
+                        T[s[pos[0]]] += 1
+                        pos.pop(0)
+                else:
+                    T[s[i]] -= 1
+                pos.append(i)
+            if a == l:
+                if ans[1] - ans[0] > pos[-1] - pos[0]:
+                    ans = (pos[0], pos[-1])
+
+    if ans[0] == -1:
+        return ""
+    else:
+        return s[ans[0]:ans[1]+1]
+
+
+print(minWindow("ADOBECODEBANC", "ABC"))
+print(minWindow("a", "a"))
+print(minWindow("a", "b"))
+# 1글자 처리 t in s 로 불가능
+print(minWindow("bba", "ab"))
+# while T[s[pos[0]]] index out of range, pos 추가
+print(minWindow("aaaaaaaaaaaabbbbbcdd", "abcdd"))
+# "bbcdd", 첫 else 문에서 T로 한 번 더 감쌌음 ( T[s[i]] )
+print(minWindow("babb", "baba"))
+# "b", 마지막 return 예외 처리 안 함


### PR DESCRIPTION
## 문제
https://leetcode.com/problems/minimum-window-substring/
문자열 2개 s, t 가 주어졌을 때 t 안의 모든 문자를 포함하는 s의 최소 부분 문자열을 구하는 문제.
단, 정답이 하나만 존재하도록 tc가 구성되어 있다고 한다.

## 초기 설계
문제 맨 아래 O(m+n) 의 알고리즘을 찾아보자는 내용을 먼저 보고 설계를 시작했다.
문자열 2개를 동시에 비교하는 순간 이미 곱셈의 시간복잡도를 가지기 때문에,
우선 찾을 문자열 t을 먼저 dictionary에 count 해두었다.

<img width="475" alt="image" src="https://user-images.githubusercontent.com/16753880/163675768-52a517bb-4486-4c65-ad17-b1ec895df1ec.png">

substring을 찾을 s를 한 번의 iteration 만에 찾기 위해서,

- s를 순회하면서 dictionary에 찾는 문자가 있을 때마다
  1. dictionary value -1, 찾은 문자의 개수 +1
      - 단, value가 이미 0인 경우에는 개수를 증가시키지 않음
  2. 찾은 문자의 위치를 [문자, 위치] 형태로 (position) list에 추가
- 찾은 문자의 개수와 t의 길이가 같으면 
  position list의 (맨 뒤 위치 - 맨 앞 위치) 로 현재 sub string 길이 업데이트

## 어려움을 겪은 내용
<img width="544" alt="image" src="https://user-images.githubusercontent.com/16753880/163675816-fd86be20-eeee-4aeb-b548-fe645a7ba7db.png">

문자열 s 내에서 t를 구성하는데 필요한 개수보다 문자가 더 많이 등장하는 경우
마지막부터 역으로 필요한 만큼만 들고 있으면 되지만,
필요없는 부분을 찾아서 지우려면 search가 필요하게 된다.
search를 없애기 위해 dictionary와 position list를 동시에 활용하는 방법을 생각했다.

1. dict에는 넘친 개수만큼 -값이 들어있을 것이고,
2. 넘친 개수들은 전부 position list에 들어있다.
3. 하지만 모든 문자열을 포함해야 하는 규칙을 지키기 위해,
  **현재 탐색하는 문자와 position list의 첫 번째 문자가 동일할 때**
  pos list 앞에서부터 value가 -인 문자를 전부 pos list에서 제외해주면 된다
