### PR TITLE
[10주차] yyj-Leetcode-1129

### DIFF
--- a/Leetcode/1129/yyj.py
+++ b/Leetcode/1129/yyj.py
@@ -1,0 +1,30 @@
+class Solution:
+    def shortestAlternatingPaths(self, n: int, redEdges: List[List[int]], blueEdges: List[List[int]]) -> List[int]:
+        res = [-1 for _ in range(n)]
+        res[0] = 0
+        var = 2
+        
+        colormap = [collections.defaultdict(set) for i in range(var)]
+        edges = [redEdges, blueEdges]
+        for color in range(var):
+            for src, dest in edges[color]:
+                colormap[color][src].add(dest)
+        
+        q = collections.deque()
+        visited_edges = set()
+        for color in range(var):
+            for node in colormap[color][0]:
+                visited_edges.add((0, node, color))
+                q.append([node, color, 1])
+            
+        while q:
+            node, color, length = q.popleft()
+            if res[node] == -1:
+                res[node] = length
+            color = (color + 1) % var
+            for n_node in colormap[color][node]:
+                if (node, n_node, color) not in visited_edges:
+                    visited_edges.add((node, n_node, color))
+                    q.append([n_node, color, length + 1])
+
+        return res


### PR DESCRIPTION
## 문제

[https://leetcode.com/problems/shortest-path-with-alternating-colors/](https://leetcode.com/problems/shortest-path-with-alternating-colors/)

## 개요

- 방향 그래프의 노드 수 n이 주어진다(0-indexed)
- 그래프의 간선은 빨강 혹은 파랑이며, 빨간색 간선 리스트 redEdges와 파란색 간선 리스트 blueEdges가 주어진다.
    - 각 간선은 [src, dest] 형태로 src에서 dest로 가는 길이 있음을 나타낸다.
    - 자기 자신을 향하는 간선이나 중복된 간선이 존재할 수 있다.
- 배열의 i번째 원소가 0번 노드에서 i번 노드로 가는 최단거리(경로가 존재하지 않을 경우 -1)인 배열을 정답으로 리턴한다.
    - 이동 규칙 : 서로 다른 색깔의 간선을 번갈아 사용하며 이동한다(빨강-파랑-빨강-../파랑-빨강-파랑-...)
    - 거리는 목표점에 도달하기 위해 사용한 간선의 수로 한다.

## 초기 설계

- res(List) : 0번 노드에서 i번 노드로 가는 최단거리를 배열의 i번째 원소로 하는 배열(정답)
    - 초기값 :  res[0] = 0, 나머지 원소는 -1
- 간선 존재 여부의 탐색 속도를 높이기 위해 dictionary를 이용한다(redmap, bluemap).
    - 간선의 색, 출발지, 도착지가 모두 같은 간선은 중복된 간선으로 따로 고려할 필요가 없다. 간선의 색에 따라 dictionary를 만들고, 출발지를 key로 하며, 각 출발지에 따른 도착지를 set으로 저장하여 중복을 제거한다.
- visited(set) : 이미 방문한 노드를 다시 방문하지 않도록 저장한다.
- 그래프 탐색을 위해 큐를 이용한다(q).
    - 큐에 넣을 원소 : [현재 노드, 직전에 지나온 간선의 색, 지금까지 지나온 간선의 수]
    - 초기값 설정 : 출발지가 0인 간선(redmap[0], bluemap[0])을 이용, 도착지 노드를 기준으로 원소를 만들어 큐에 넣는다.
    - 큐에서 원소를 추출하고, res 배열에 현재 노드까지의 거리를 업데이트한다. 이미 지나온 노드는 다시 지나가지 않으므로, 별도의 확인 과정 없이 값을 넣어도 된다.
    - 현재 노드를 출발지로 할 때 직전에 지나온 간선과 다른 색의 간선을 이용해 갈 수 있는 도착지 노드를 기준으로 원소를 만들어 큐에 넣는다(해당 도착지 노드는 visited에 추가). 이 과정을 큐가 완전히 빌 때까지 반복한다.

## 어려움을 겪은 내용 & 해결 방법

### D1. 한 노드를 두 번 이상 방문하거나, 사이클이 있는 경우의 처리

위의 과정을 거쳐 작성한 코드는 아래와 같다.

```python
class Solution:
    def shortestAlternatingPaths(self, n: int, redEdges: List[List[int]],
			blueEdges: List[List[int]]) -> List[int]:

        res = [-1 for _ in range(n)]
        res[0] = 0
        
        redmap = collections.defaultdict(set)
        bluemap = collections.defaultdict(set)
        for rs, rd in redEdges:
            redmap[rs].add(rd)
        # ... blueEdges, bluemap ...
        
        q = collections.deque()
        visited = set({0})
        for node in redmap[0]:
            visited.add(node)
            q.append([node, 'red', 1])
        # ... bluemap, 'blue' ...
            
        while q:
            node, color, length = q.popleft()
            res[node] = length
            if color == 'red':
                for n_node in bluemap[node]:
                    if n_node not in visited:
                        visited.add(n_node)
                        q.append([n_node, 'blue', length + 1])
            else:
                # ... redmap, 'red' ...

        return res
```

위 코드를 실행한 결과, n = 5, redEdges = [[0,1],[1,2],[2,3],[3,4]], blueEdges = [[1,2],[2,3],[3,1]]인 테스트케이스에 대해 WA를 받았다(Output : [0, 1, 2, 3, -1] / Expected : [0, 1, 2, 3, 7] 

해당 테스트케이스를 그림으로 나타내면 다음과 같다. 4번 노드를 방문하는 경로는 초록색 숫자로 표기하였다.

![graph_1](https://user-images.githubusercontent.com/93690278/164889520-feb4e8b0-592c-46af-ac0f-ca906e40572f.png)

위의 사례만 보면 노드는 중복 방문이 가능하니 이미 방문한 노드를 저장하는 visited만 없애면 될 것처럼 보인다. 하지만 사이클이 있는 그래프가 존재한다면, 이 방법은 통하지 않을 것이다.

해당 케이스는 아주 간단하게 발견할 수 있다. 위 그래프에 빨간색 간선 [3,1]만 추가해도 사이클이 생긴다.

![graph_2](https://user-images.githubusercontent.com/93690278/164889513-fb898472-47ab-4d64-87f3-f9ab406ae7fc.png)

### S1. 방문한 간선의 목록 유지

이미 방문한 간선을 또 방문하는 경우는 절대 최단거리가 될 수 없다.

현재 노드에 도착할 때까지 방문한 간선의 목록을 유지하고, 이미 방문한 간선은 다시 방문하지 않도록 하자. 간선의 수는 유한하므로 사이클의 무한루프 문제도 해결된다.

큐를 이용하여 bfs를 하므로, res 배열의 각 원소는 최초로 업데이트될 때가 최솟값임이 보장된다. 노드 i에 도착했을 때, res[i] = -1인 경우만 거리를 업데이트하도록 하자.

```python
class Solution:
    def shortestAlternatingPaths(self, n: int, redEdges: List[List[int]],
			blueEdges: List[List[int]]) -> List[int]:
        res = [-1 for _ in range(n)]
        res[0] = 0
        
        redmap = collections.defaultdict(set)
        bluemap = collections.defaultdict(set)
        for rs, rd in redEdges:
            redmap[rs].add(rd)
        # ... blueEdges, bluemap ...
        
        q = collections.deque()
        for node in redmap[0]:
            q.append([node, 'red', 1, **set({(0, node, 'red')})**])
        # ... bluemap, 'blue' ...
            
        while q:
            node, color, length, route = q.popleft()
            **if res[node] == -1:
                res[node] = length**
            if color == 'red':
                for n_node in bluemap[node]:
                    **if (node, n_node, 'blue') not in route:**
                        route.add((node, n_node, 'blue'))
                        q.append([n_node, 'blue', length + 1, route])
            else:
                # ... redmap, 'red' ...

        return res
```

bfs를 수행함에 따라 각 간선의 탐색 순서는 보장되고, 탐색 규칙에 따라 맨 처음에 빨간색 간선을 이용할 때 사용될 간선의 집합과 맨 처음에  파란색 간선을 이용할 때 사용될 간선의 집합에는 교집합이 없다.

따라서, 큐의 각 원소마다 방문한 간선의 목록(route)을 유지할 필요 없이 전체 탐색 과정에서 사용할 방문 목록 하나만 두어도 된다.

그리고 색깔 변경을 if-else문과 중복 코드 없이 수행할 수 있도록 코드를 조정하였다.

```python
class Solution:
    def shortestAlternatingPaths(self, n: int, redEdges: List[List[int]],
			blueEdges: List[List[int]]) -> List[int]:
        res = [-1 for _ in range(n)]
        res[0] = 0
        var = 2
        
        colormap = [collections.defaultdict(set) for i in range(var)]
        edges = [redEdges, blueEdges]
        for color in range(var):
            for src, dest in edges[color]:
                colormap[color][src].add(dest)
        
        q = collections.deque()
        **visited_edges = set()**
        for color in range(var):
            for node in colormap[color][0]:
                visited_edges.add((0, node, color))
                q.append([node, color, 1])
            
        while q:
            node, color, length = q.popleft()
            if res[node] == -1:
                res[node] = length
            **color = (color + 1) % var**
            for n_node in colormap[color][node]:
                if (node, n_node, color) not in visited_edges:
                    visited_edges.add((node, n_node, color))
                    q.append([n_node, color, length + 1])

        return res
```