### PR TITLE
[12주차] SUB-baekjoon-13549

### DIFF
--- a/baekjoon/13549/SUB.py
+++ b/baekjoon/13549/SUB.py
@@ -1,0 +1,30 @@
+from collections import deque
+
+n, k = map(int, input().split())
+arr = [-1] * 100003
+ans = 0
+
+q = deque()
+q.append(n)
+arr[n] = 0
+
+while q:
+    cur = q.popleft()
+
+    if cur == k:
+        ans = arr[cur]
+        break
+
+    if 0 <= cur*2 <= 100001 and arr[cur*2] == -1:
+        arr[cur*2] = arr[cur]
+        q.appendleft(cur*2)
+    if 0 <= cur - 1 <= 100001 and arr[cur - 1] == -1:
+        arr[cur - 1] = arr[cur] + 1
+        q.append(cur - 1)
+    if 0 <= cur+1 <= 100001 and arr[cur+1] == -1:
+        arr[cur+1] = arr[cur]+1
+        q.append(cur+1)
+
+
+
+print(arr[k])


### PR DESCRIPTION
## 문제
<https://www.acmicpc.net/problem/13549>
## 어려움을 겪은 내용
이전에 풀었던 숨바꼭질 문제와 비슷한 방식으로 접근(BFS)
단, 이번에는 순간 이동에 걸리는 시간이 0초이기 때문에 (이전 문제는 1초) 도달하려는 위치가 이미 방문했었어도 현재 걸린 시간이 더 짧으면 더 짧은 시간으로 갱신하는 방법으로 구현하였지만 시간 초과가 발생하였다.
## 해결 방법
기본적은 해법은 BFS와 동일하게 가지만, 순간 이동을 한 경우의 우선순위를 높여서 먼저 계산해준다.
우선순위 큐를 사용하여도 되지만, 이 경우 단순히 순간 이동을 한 경우를 pushleft, +1과 -1 이동한 경우를 push로 나누어서 따로 큐에 넣어주었다.
이렇게 해도 시간 초과가 발생하였는데, +1과 -1 사이에서도 -1쪽을 먼저 진행하는 편이 빠르기 때문에(-1을 한 후 순간 이동을 하여 도착하는 경우, 도착 지점이 시작 지점보다 앞이어서 -1을 계속 선택하는 방법밖에 존재하지 않는 경우) 
```python
    if 0 <= cur*2 <= 100001 and arr[cur*2] == -1:
        arr[cur*2] = arr[cur]
        q.appendleft(cur*2)
    if 0 <= cur - 1 <= 100001 and arr[cur - 1] == -1:
        arr[cur - 1] = arr[cur] + 1
        q.append(cur - 1)
    if 0 <= cur+1 <= 100001 and arr[cur+1] == -1:
        arr[cur+1] = arr[cur]+1
        q.append(cur+1)
```
와 같은 순서로 push해주었다.