### PR TITLE
[12주차] yyj-Leetcode-839

### DIFF
--- a/Leetcode/839/yyj.py
+++ b/Leetcode/839/yyj.py
@@ -1,0 +1,51 @@
+class Union_find:
+    def __init__(self, n: int) -> None:
+        self.root = [i for i in range(n)]
+        self.rank = [1] * n
+        self.group = n
+        
+    def find(self, x: int) -> int:
+        if x == self.root[x]:
+            return x
+        self.root[x] = self.find(self.root[x])
+        return self.root[x]
+    
+    def union(self, x: int, y: int) -> None:
+        root_x = self.find(x)
+        root_y = self.find(y)
+        if root_x != root_y:
+            if self.rank[root_x] > self.rank[root_y]:
+                self.root[root_y] = root_x
+            elif self.rank[root_x] < self.rank[root_y]:
+                self.root[root_x] = root_y
+            else:
+                self.root[root_y] = root_x
+                self.rank[root_x] += 1
+            self.group -= 1
+    
+    def count(self) -> int:
+        return self.group
+
+class Solution:
+    def numSimilarGroups(self, strs: List[str]) -> int:
+        strs = list(set(strs))
+        str_map = collections.defaultdict(int)
+        for i, s in enumerate(strs):
+            str_map[s] = i
+        
+        n, length = len(strs), len(strs[0])
+        uf = Union_find(n)
+        for i in range(n):
+            for j in range(i+1, n):
+                unmatched = 0
+                is_union = True
+                for k in range(length):
+                    if strs[i][k] != strs[j][k]:
+                        unmatched += 1
+                    if unmatched > 2:
+                        is_union = False
+                        break
+                if is_union:
+                    uf.union(i, j)
+        
+        return uf.count()


### PR DESCRIPTION
## 문제

(https://leetcode.com/problems/count-number-of-rectangles-containing-each-point/)

(Leetcode Weekly Contest 290 #3 - April 24, 2022)

## 개요

- 길이가 서로 같은 문자열
    - rectangle[i] = [x, y]일 때, x는 밑변의 길이, y는 직사각형의 높이를 나타낸다. 사각형의 좌하단 꼭짓점 좌표는 (0, 0), 우상단 꼭짓점 좌표는 (x, y)이다.
    - 0 ≤ i < 5 * 10^4, **1 ≤ x ≤ 10^9, 1 ≤ y ≤ 100**
- 점을 표현하는 순서쌍 j개를 담은 2차원 정수 배열 points가 주어진다(중복 없음).
    - points[j] = [x, y]일 때, 0 ≤ j < 5 * 10^4, **1 ≤ x ≤ 10^9, 1 ≤ y ≤ 100**
- j번째 점이 포함되는 사각형의 수를 배열의 j번째 원소로 갖는 길이 len(points)인 배열을 정답으로 리턴한다.
    - 사각형의 경계선(테두리 부분)에 점이 위치할 경우 포함되는 것으로 본다.

## 초기 설계

- Brute force? : 한 점에 대해 모든 직사각형을 순회하며 포함 여부를 확인할 경우, Worst case의 계산량은 (5 * 10^4)^2 = 25 * 10^8로 1억을 초과한다(TLE 예상). 탐색 공간을 줄이거나, 일부만 확인하여 찾아내는 전략이 필요하다.
- 어떤 점이 직사각형에 포함되는지를 확인하는 방법을 알아보자. r = [x1, y1], p = [x2, y2]일 때, (x1 ≥ y1 && x2 ≥ y2)이면 p는 r에 포함된다.
- 직사각형의 x좌표와 y좌표가 크기 순으로 정렬되어 있다면 확인하기 용이할 것이다. 아래는 첫 번째 정렬 기준을 x좌표, 두 번째 정렬 기준을 y좌표로 하여 정렬한 그림이다.
- 이 문제에는 가능한 직사각형의 높이(=y좌표) 범위[1, 100]가 가능한 밑변의 길이(=x좌표) 범위[1, 10^9]보다 훨씬 적다는 제약조건이 있다.
    - 위 그림과 같이 정렬할 경우, 주어지는 직사각형의 수가 최대(5 * 10^4)이고 좌표가 균등하게 분포할 때가 최악에 가까울 것이다. 이 때, x좌표를 key로 할 경우 각 key에 속하는 평균 좌표 수의 기댓값은 1이고, y좌표를 key로 할 경우 5 * 10^2이다.
    - binary search의 효율성은 탐색 공간이 클수록 진가를 발휘하므로, x좌표에 binary search를 적용할 수 있도록 직사각형의 y좌표를 key로 하도록 하자.
    - 직사각형의 y좌표를 key로 하고, 각 key에 대해 직사각형의 x좌표를 크기 순서대로 저장한다(rec_y_maps(2D list) / 배열의 인덱스가 key가 됨)
    - points 배열의 각 점 [x2, y2]에 대해 y2 ≤ j < 101인 모든 rec_y_maps[j]에 속하는 직사각형을 [x1, j]라고 하자. 각 rec_y_maps[j]에서 x1 ≥ x2가 되는 가장 작은 x1을 갖는 좌표의 인덱스를 확인하여 전체 좌표수에서 뺀 값의 누적합을 답으로 한다.

## 어려움을 겪은 내용 & 해결 방법

x좌표, y좌표가 있으면 자연스럽게 놓인 순서에 따라 x좌표를 첫 번째 기준, y좌표를 두 번째 기준으로 잡게 되다 보니 발상의 전환을 해야 하는 부분이 가장 어려웠다.

제약조건을 확인하고 binary search의 시간복잡도상 특징을 떠올리니 힌트를 얻을 수 있었다. 제약조건 확인의 중요성을 느낄 수 있는 문제였다😋