### PR TITLE
[13주차] yyj-Leetcode-1631

### DIFF
--- a/Leetcode/1631/yyj.py
+++ b/Leetcode/1631/yyj.py
@@ -1,0 +1,36 @@
+class Solution:
+    def minimumEffortPath(self, heights: List[List[int]]) -> int:
+        def is_valid_vertex(r: int, c: int) -> bool:
+            return 0 <= r < row and 0 <= c < col
+        
+        row, col = len(heights), len(heights[0])
+        start, end = (0, 0), (row-1, col-1)
+        adj_move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        not_visited = set()
+        minheap = []
+        max_effort = collections.defaultdict(int)
+        connections = collections.defaultdict(list)
+        
+        for r in range(row):
+            for c in range(col):
+                max_effort[(r, c)] = 0 if (r, c) == start else sys.maxsize
+                not_visited.add((r, c))
+                for dy, dx in adj_move:
+                    nr, nc = r+dy, c+dx
+                    if is_valid_vertex(r+dy, c+dx):
+                        effort = abs(heights[nr][nc] - heights[r][c])
+                        connections[(r, c)].append([(nr, nc), effort])
+        
+        heapq.heappush(minheap, [max_effort[start], start])
+        while minheap and not_visited:
+            effort, src = heapq.heappop(minheap)
+            if src not in not_visited:
+                continue
+            for dest, effort in connections[src]:
+                curr_max_effort = max(effort, max_effort[src])
+                if max_effort[dest] > curr_max_effort:
+                    max_effort[dest] = curr_max_effort
+                    heapq.heappush(minheap, [max_effort[dest], dest])
+            not_visited.remove(src)
+            
+        return max_effort[end]


### PR DESCRIPTION
## 문제

(https://leetcode.com/problems/path-with-minimum-effort/)

## 개요

- 크기 (rows * columns) 인 2차원 배열 height가 주어진다.
- 출발지는 height[0][0], 도착지는 height[rows-1][columns-1]이며, 상하좌우 방향으로 움직여 갈 수 있다.
- 인접한 두 셀 (r1, c1), (r2, c2)에 대하여 (r1, c1) → (r2, c2) 이동에 대한 effort는 두 셀 값의 차이의 절댓값이다.
- 전체 경로의 effort는 경로에 포함된 인접한 셀 간의 effort 중 최댓값이다. 이 때, 출발지에서 도착지로 가는 effort의 최솟값을 리턴한다.

## 초기 설계

- Graph! : 주어진 문제는 인접한 두 셀 간의 관계와 이동을 이용하여 푸는 문제이다. 따라서, height 배열은 셀 하나하나를 vertex, 인접한 셀 값의 차이의 절댓값을 edge의 가중치(effort)로 하는 그래프로 보아도 무방하다.
    - connections : 배열의 2차원 좌표를 노드 번호이자 key로 하여, 해당 노드에 인접한 노드 번호와 effort를 리스트 형식으로 저장한다.
        - connections[(r, c)] = [[(nr, nc), effort], ..]

![1631-1_matrix_to_graph](https://user-images.githubusercontent.com/93690278/168427972-2d7ca801-98ae-46a8-b37a-5a3827031a88.png)

- BFS? : 각 이동에 대한 가중치가 일정하지 않으므로 이동 횟수가 최소일 때 답이 최소가 된다는 보장이 없다. 단순 BFS로는 원하는 답을 찾기 어려우니, 가중치가 있는 그래프에서 최단 경로를 찾는 다익스트라 알고리즘을 활용해 보자.
- Dijkstra? : 다익스트라 알고리즘의 기본형은 특정 한 노드(src)에서 모든 노드(dest)까지의 이동 비용을 구하며, 그 값은 src에서 출발하여 dest에 도착하는 이동 비용의 누적합의 최솟값이다.  문제에서 원하는 값은 경로에 속한 인접한 셀 간 이동 비용의 최댓값이 최소가 되게 하는 것이므로, 누적합을 구하는 과정을 경로를 이동하면서 이동 비용의 최댓값을 갱신하는 것으로 바꾸어 보면 될 것 같다.
    - priority queue : 다익스트라 알고리즘은 매번 현재 시점까지 발견된 src로부터의 거리가 가장 짧은 노드를 골라, 그와 인접한 노드의 최단거리를 갱신한다. 그런 노드를 고르는 데 걸리는 시간을 줄이기 위해 priority queue를 이용한다(minheap).
        - python의 heapq 라이브러리를 이용, 최소 힙을 구현한다. 원소가 여러 개인 리스트를 넣을 경우, 첫 번째 원소를 기준으로 정렬하므로 힙에 삽입하는 원소의 형태를 [이동 비용, 노드 번호]로 하자.
        - 탐색 시간 :  O(n) in linear search → O(logn) using priority queue
    - not_visited(set) : 답을 이미 발견한 노드를 재탐색하지 않도록 한다. 인접 노드에 대한 갱신 작업을 모두 끝내면, 해당 노드를 삭제한다.
    - max_effort(dict, key=(r, c)) : (0, 0)에서 (r, c)까지 가는 경로에서 발견된 effort의 최댓값을 저장한다.

## 어려움을 겪은 내용 & 해결 방법

### 1. 이동 비용 갱신 로직 작성

처음 작성한 코드는 다음과 같다.

주어진 테스트케이스는 모두 통과하였으나, 제출했을 때 WA를 받았다.

```python
class Solution:
    def minimumEffortPath(self, heights: List[List[int]]) -> int:
        def is_valid_vertex(r: int, c: int) -> bool:
            return 0 <= r < row and 0 <= c < col
        
        row, col = len(heights), len(heights[0])
        start, end = (0, 0), (row-1, col-1)
        adj_move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
        not_visited = set()
        minheap = []
        max_effort = collections.defaultdict(int)     # max_effort[(r, c)] = weight
        
        # construct a graph from matrix
				...
        
        heapq.heappush(minheap, [max_effort[start], start])
        while minheap and not_visited:
            effort, src = heapq.heappop(minheap)
            if src not in not_visited:
                continue
            for dest, effort in connections[src]:
                if dest in not_visited:
                    max_effort[dest] = max(effort, max_effort[src])
                    heapq.heappush(minheap, [max_effort[dest], dest])
            not_visited.remove(src)
            
        return max_effort[end]
```

max_effort[dest] = max(effort, max_effort[src])의 의미를 다시 분석해보자.

- 아래 두 값 중 큰 값을 최초 출발지 (0, 0)에서 dest에 이르는 경로의 effort로 한다.
    - effort : 현재 탐색중인 노드(src)에서 인접한 노드(dest)로 이동할 때의 effort(=두 셀 값의 차의 절댓값)
    - max_effort[src] : 최초 출발지(0, 0)에서 현재 탐색중인 노드(src)에 이르는 경로의 effort(=경로에 포함된 인접한 두 셀의 effort 중 최댓값)

max_effort[dest]는 ‘현재까지 발견된 최초 출발지 (0, 0)에서 dest에 이르는 경로의 effort 중 최솟값’이다. max(effort, max_effort[src])는 src를 탐색함으로써 새롭게 발견한, (0,0) → ... → src → dest에 이르는 경로의 effort이다.
max_effort[dest]는 (0, 0) → ... → dest에 이르는 경로의 effort가 더 작게 되는 경우를 발견했을 때 갱신되어야 한다.

따라서, max_effort[dest]와 max(effort, max_effort[src])를 비교하여 max_effort[dest] > max(effort, max_effort[src])일 때 max_effort[dest] 값을 갱신해주어야 한다.

```python
class Solution:
    def minimumEffortPath(self, heights: List[List[int]]) -> int:

...

        heapq.heappush(minheap, [max_effort[start], start])
        while minheap and not_visited:
            effort, src = heapq.heappop(minheap)
            if src not in not_visited:
                continue
            for dest, effort in connections[src]:
                curr_max_effort = max(effort, max_effort[src])
                **if max_effort[dest] > curr_max_effort:
                    max_effort[dest] = curr_max_effort
                    heapq.heappush(minheap, [max_effort[dest], dest])**
            not_visited.remove(src)
```