### PR TITLE
[13주차]김준근-programmers-81305

### DIFF
--- a/programmers/81305/김준근.py
+++ b/programmers/81305/김준근.py
@@ -1,0 +1,52 @@
+import sys
+
+sys.setrecursionlimit(10000000)
+
+INF = 987654312
+
+
+def solution(k, num, links):
+    has_parent = [False for _ in range(len(num))]
+    for children in links:
+        for child in children:
+            if child != -1:
+                has_parent[child] = True
+
+    root = 0
+    for i, p in enumerate(has_parent):
+        if not p:
+            root = i
+            break
+
+    max_result = sum(num) + 1
+    min_result = max(1, sum(num) // k)
+
+    def count_group(group_size, root_node):
+        if root_node == -1:
+            return 1, 0
+        if num[root_node] > group_size:
+            return INF, INF
+        left_group_count, left_group_root_size = count_group(group_size, links[root_node][0])
+        right_group_count, right_group_root_size = count_group(group_size, links[root_node][1])
+
+        if left_group_root_size + right_group_root_size + num[root_node] <= group_size:
+            return left_group_count + right_group_count - 1, left_group_root_size + right_group_root_size + num[
+                root_node]
+        min_group_size = min(left_group_root_size, right_group_root_size)
+        if min_group_size + num[root_node] <= group_size:
+            return left_group_count + right_group_count, min_group_size + num[root_node]
+
+        return left_group_count + right_group_count + 1, num[root_node]
+
+    while min_result < max_result:
+        mid = (min_result + max_result) // 2
+        group_count, group_root_size = count_group(mid, root)
+        if group_count > k:
+            min_result = mid + 1
+        else:
+            max_result = mid
+
+    return min_result
+
+
+print(solution(3, [12, 30, 1, 8, 8, 6, 20, 7, 5, 10, 4, 1], [[-1, -1], [-1, -1], [-1, -1], [-1, -1], [8, 5], [2, 10], [3, 0], [6, 1], [11, -1], [7, 4], [-1, -1], [-1, -1]]))


### PR DESCRIPTION
## 문제
https://programmers.co.kr/learn/courses/30/lessons/81305

## 어려움을 겪은 내용

풀이 방법을 전혀 생각해내지 못했다. 처음에는 간선을 k-1개 자를 수 있는 경우의 수를 모두 해보려고했는데 이는 nCk로 당연히 시간 초과가 발생한다.

## 해결 방법

문제 해석을 다르게 해야되는 과정이 어려웠다. 모든 간선을 잘라보는 것은 당연히 시간초과가 발생한다.

1. 각 그룹의 인원을 L명 이하로 만들기 위해서 몇 개의 그룹이 필요한지 구하는 문제로 바꾸고, 
2. 이 그룹의 수가 처음으로 k가되는 L을 바이너리 서치로 풀어야된다.

L의 범위가 (총 인원/ k)~(총 인원) 사이라는 것을 알면 바이너리 서치로 접근할 수 있다.

1번 소문제를 해결하기 위해서 dfs를 이용했다.

현재 노드를 루트 노드로 하는 서브 트리에서 L명 이하로 만들기 위한 (그룹의 개수, 루트 노드를 포함한 그룹의 인원 수)를 반환하는 함수를 만들어 자신의 부모 노드가 자신을 하나의 그룹으로 합칠 수 있는지 판별하여 최대한 적은 그룹을 만들도록 계산한다.

1번 과정에서 O(log(len(num)) 이 필요하고, 

2번 과정에서 O(log(sum(num)) 이 필요하다.

len(num)의 최대값 == 10000

sum(num)의 최대값 == 100000000