### PR TITLE
[14주차] yyj-Leetcode-76

### DIFF
--- a/Leetcode/76/yyj.py
+++ b/Leetcode/76/yyj.py
@@ -1,0 +1,29 @@
+class Solution:
+    def minWindow(self, s: str, t: str) -> str:
+        remain = len(t)
+        overcounted = 0
+        t_counter = collections.Counter(t)
+        
+        res = ''
+        maxlen = sys.maxsize        
+        l = 0
+        for r, r_char in enumerate(s):
+            t_counter[r_char] -= 1
+            if t_counter[r_char] >= 0:
+                remain -= 1
+                
+            if not remain:
+                while l < r:
+                    l_char = s[l]
+                    if t_counter[l_char] < 0:
+                        t_counter[l_char] += 1
+                        l += 1
+                    else:
+                        break
+                
+                currlen = r - l + 1
+                if currlen < maxlen:
+                    maxlen = currlen
+                    res = s[l : r+1]
+            
+        return res

--- a/Leetcode/76/yyj.py
+++ b/Leetcode/76/yyj.py
@@ -1,7 +1,6 @@
 class Solution:
     def minWindow(self, s: str, t: str) -> str:
         remain = len(t)
-        overcounted = 0
         t_counter = collections.Counter(t)
         
         res = ''


### PR DESCRIPTION
## 문제

(https://leetcode.com/problems/minimum-window-substring/)

## 개요

- 영어 대소문자로 구성된 문자열  s, t가 주어진다.
- 문자열 t에 들어있는 모든 문자(중복되는 문자 포함)가 포함되는 s의 부분문자열 중 가장 짧은 문자열을 정답으로 리턴한다.
    - s의 부분문자열은 문자열 s에서 연속된 일부분이다. s = ‘abcde’일 때, ‘abc’는 부분문자열이지만 ‘ace’는 부분문자열이 아니다.
    - 정답이 되는 s의 부분문자열은 t에 들어있는 모든 문자를 포함하여야 하며, t에 포함된 순서와는 달라도 된다. s = ‘caba’, t = ‘baa’일 때, ‘aba’가 정답이 된다(’ba’, ‘ab’는 정답이 아니다).
- 가능한 정답이 없을 경우 빈 문자열을 리턴한다.

## 초기 설계

- 문자열 t에 등장하는 모든 문자를 s에서 찾았을 때, 처음으로 찾은 자리(l)부터 모든 문자를 찾았을 때 도달한 자리(r)까지가 정답 후보가 된다. 이전까지 찾은 정답보다 이번에 찾은 정답의 길이가 짧으면 정답을 갱신하며, 덜 찾은 문자가 생길 때까지 왼쪽 포인터(l)를 오른쪽으로 옮긴다. 오른쪽 포인터(r)가 s의 모든 문자를 순회할 때까지 반복한다.
- 발견 상태를 기록하는 배열을 활용한다.
    - appearance : 문자열 s 전체를 순회하면서 t에 포함된 문자가 s에서 나타날 때, [포함된 문자, s에서의 위치(index)] 형태로 기록하였다.
- 찾은 상태를 검사하기 위해 int형 변수 2개를 사용한다.
    - remain : t에 포함된 문자를 s에서 발견했을 때 항상 갱신
    - overcounted : t에 포함된 문자를 t에서 등장하는 갯수를 초과하여 발견하였을 때 갱신

## 어려움을 겪은 내용 & 해결 방법

### 1. 최소 길이 문자열 발견

처음 작성한 코드는 다음과 같다.

주어진 테스트케이스는 모두 통과하였으나, 제출했을 때 WA를 받았다.

```python
class Solution:
    def minWindow(self, s: str, t: str) -> str:
        remain = len(t)
        overcounted = 0
        t_counter = collections.Counter(t)
        t_finder = set(' '.join(t).split(' '))
        
        res = ''
        maxlen = sys.maxsize
        appearance = []
        for i, char in enumerate(s):
            if char in t_finder:
                appearance.append([i, char])
        
        if not appearance:
            return res

        l = 0
        for r in range(len(appearance)):
            r_idx, char = appearance[r]
            t_counter[char] -= 1
            remain -= 1
            if t_counter[char] < 0:
                overcounted -= 1

            if remain == overcounted:
                l_idx = appearance[l][0]
                currlen = r_idx - l_idx + 1
                if currlen < maxlen:
                    maxlen = currlen
                    res = s[l_idx : r_idx+1]

                while l < r:
                    char = appearance[l][1]
                    if t_counter[char] < 0:
                        overcounted += 1
                    remain += 1
                    t_counter[char] += 1
                    l += 1
                    if t_counter[char] >= 1:
                        break
                    
        return res
```

s = ‘bba’, t = ‘ba’일 때, 실제 정답은 ‘ba’지만 이 코드로는 발견할 수 없다.

l = 0, r = 2가 되어 ‘bba’를 기록한 후 t에 속한 문자 중 발견하지 못한 문자가 나올 때까지 l을 오른쪽으로 옮기면 l = 2, r = 2가 된다. 위 코드로는 ‘ba’를 기록할 수가 없다.

문자열의 배치에 따라 모든 문자를 발견하는 과정에서 t에 등장하는 갯수를 초과하여 발견하는 경우가 있으므로, 모든 문자를 발견하고 난 다음 왼쪽에서부터 일부 문자를 삭제해도 모든 문자를 발견한 상태가 유지되는지 확인해줄 필요가 있다.

이 문제점을 해결하는 과정에서 왼쪽에서부터 일부 문자를 삭제할지를(= 왼쪽 포인터(l)를 오른쪽으로 움직일지를) 결정하는 조건을 잘 설정하면 굳이 overcounted 변수를 사용할 필요가 없음을 발견하였다.

수정한 코드는 다음과 같다.

```python
class Solution:
    def minWindow(self, s: str, t: str) -> str:
        ...
        
        l = 0
        for r in range(len(appearance)):
            r_idx, r_char = appearance[r]
            t_counter[r_char] -= 1
            if t_counter[r_char] >= 0:
                remain -= 1
                
            # if every character in t is found,
            # shrink to right for finding shorter one(while loop) and update answer
            # for example, let t = 'abc', 'b~a~b~c' can be shrinked to 'a~b~c'
            if not remain:
                while l < r:
                    l_char = appearance[l][1]
                    # if t_counter[l_char] is zero, shrinking to right will violate condition
                    # so escape the while loop
                    if t_counter[l_char] == 0:
                        break
                    t_counter[l_char] += 1
                    l += 1
                
                l_idx = appearance[l][0]
                currlen = r_idx - l_idx + 1
                if currlen < maxlen:
                    maxlen = currlen
                    res = s[l_idx : r_idx+1]
            
        return res
```

s에서 발견한 모든 문자에 대해 counter 값을 감소시키면서, s에서 t에 포함되는 문자를 발견하였을 때만 remain 값을 감소시킨다.

counter의 상태는 t에 포함되지 않으면서 발견된 문자의 경우 항상 0 미만, t에 포함된 문자의 경우 항상 0 이상이다.

remain = 0이 되었을 때 while 루프를 돌면서 왼쪽 포인터(l)를 오른쪽으로 움직일 수 있는지 검사한다.

l이 가리키는 문자에 대한 counter 값이 0이 아니라면, t에 포함되지 않으면서 발견된 문자이거나 t에 포함된 갯수를 초과하여 발견된 문자라는 뜻이다. 이 문자는 제외해도 무방하므로 오른쪽으로 이동할 수 있다.

만약 counter 값이 0이라면, 포인터를 옮겨 이 문자를 제외해 버리면 t에 있는 문자를 모두 발견하지 못한 상태가 된다는 뜻이다. 더 이상 포인터를 옮길 수 없는 지점에 도달하였으므로 while 루프를 탈출하여 정답을 업데이트한다.

아래 코드는 appearance 배열을 사용하지 않고 같은 로직으로 작성한 코드이다.

```python
class Solution:
    def minWindow(self, s: str, t: str) -> str:
        ...   
        l = 0
        for r, r_char in enumerate(s):
            t_counter[r_char] -= 1
            if t_counter[r_char] >= 0:
                remain -= 1
                
            if not remain:
                while l < r:
                    l_char = s[l]
                    if t_counter[l_char] == 0:
                        break
                    t_counter[l_char] += 1
                    l += 1
                
                currlen = r - l + 1
                if currlen < maxlen:
                    maxlen = currlen
                    res = s[l : r+1]
            
        return res
```