### PR TITLE
[15주차] 김준근-programmers-92344

### DIFF
--- a/programmers/92344/김준근.py
+++ b/programmers/92344/김준근.py
@@ -1,0 +1,35 @@
+def solution(board, skill):
+    height = len(board)
+    width = len(board[0])
+
+    difference_board = [[0 for _ in range(width)] for _ in range(height)]
+
+    for s in skill:
+        type, r1, c1, r2, c2, degree = s[0], s[1], s[2], s[3], s[4], s[5]
+        if type == 1:
+            degree *= -1
+
+        difference_board[r1][c1] += degree
+        if r2 + 1 < height:
+            difference_board[r2 + 1][c1] -= degree
+        if c2 + 1 < width:
+            difference_board[r1][c2 + 1] -= degree
+        if c2 + 1 < width and r2 + 1 < height:
+            difference_board[r2 + 1][c2 + 1] += degree
+
+    answer = 0
+
+    for i in range(1, height):
+        for j in range(width):
+            difference_board[i][j] += difference_board[i - 1][j]
+
+    for i in range(1, width):
+        for j in range(height):
+            difference_board[j][i] += difference_board[j][i - 1]
+
+    for i in range(height):
+        for j in range(width):
+            if board[i][j] + difference_board[i][j] > 0:
+                answer += 1
+    return answer
+


### PR DESCRIPTION
## 문제
https://programmers.co.kr/learn/courses/30/lessons/92344

## 어려움을 겪은 내용
처음에 접근한 방법은 중복된 연산(덧셈, 뺄셈)을 피하기 위해서 배열의 표현을 자신의 왼쪽 또는 위쪽의 차이로 나타내려고 했다. 만약 자신의 왼쪽의 차이로 표현하면 아래 사진과 같다.

![image](https://user-images.githubusercontent.com/4648244/170230678-d69c44dd-6c13-4c62-921a-2a742e181fac.png)

이렇게 하고 배열의 가로 길이가 더 길도록 transpose 하면 해결될 것이라고 생각했다. 

O(배열 세로 길이 * skill 길이)로 최악의 경우는 31 * 250000지만 시간초과가 발생했다.


## 해결 방법

결국 다른 사람 풀이를 확인했다.

잘못된 풀이와 비슷하지만 조금 달랐다.

1. 누적합을 이용함
2. 연산에 대해서만 누적합을 계산함

누적합은 x, y의 값을 확인하기 위해서는 (0, 0)부터 (x, y)까지의 모든 값을 더하는 형식이다. 위 배열을 누적합으로 변환하면 아래와 같다.

```python
n n n 0
n n n 0
n n n 0
0 0 0 0
```

```python
n 0 0 -n
0 0 0 0
0 0 0 0
-n 0 0 n
```

누적합을 이용하면 하나의 연산에대해서 값 업데이트가 4번만 일어나므로 O(skill 길이)로 해결이 가능해진다.

그리고 초기 값에대해서 누적합으로 변환하려고 하면 연산이 복잡해지지만 생각해보니 초기 값은 굳이 누적합으로 연산할 필요가 없었다.

## 참고 자료

https://tech.kakao.com/2022/01/14/2022-kakao-recruitment-round-1/#문제-6-파괴되지-않은-건물
