### PR TITLE
[15주차] yyj-Leetcode-778

### DIFF
--- a/Leetcode/778/yyj_unionfind.py
+++ b/Leetcode/778/yyj_unionfind.py
@@ -1,0 +1,62 @@
+class Union_Find:
+    def __init__(self, size: int) -> None:
+        self.root = [[[r, c] for c in range(size)] for r in range(size)]
+        self.rank = [[1] * size for _ in range(size)]
+        
+    def find(self, x: List[int]) -> List[int]:
+        r, c = x
+        if x == self.root[r][c]:
+            return x
+        self.root[r][c] = self.find(self.root[r][c])
+        return self.root[r][c]
+    
+    def union(self, x: List[int], y: List[int]) -> None:
+        root_x = self.find(x)
+        root_y = self.find(y)
+        if root_x != root_y:
+            xr, xc = root_x
+            yr, yc = root_y
+            if self.rank[xr][xc] > self.rank[yr][yc]:
+                self.root[yr][yc] = root_x
+            elif self.rank[xr][xc] < self.rank[yr][yc]:
+                self.root[xr][xc] = root_y
+            else:
+                self.root[yr][yc] = root_x
+                self.rank[xr][xc] += 1
+    
+    def connected(self, x: List[int], y: List[int]) -> bool:
+        return self.find(x) == self.find(y)
+
+class Solution:
+    def swimInWater(self, grid: List[List[int]]) -> int:
+        
+        def is_valid_coord(r: int, c: int) -> bool:
+            return 0 <= r < N and 0 <= c < N
+        
+        N = len(grid)
+        if N == 1:
+            return 0
+        
+        start = [0, 0]
+        goal = [N-1, N-1]
+        pq = []
+        is_activated = [[False] * N for _ in range(N)]
+        move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        
+        for r in range(N):
+            for c in range(N):
+                pq.append([grid[r][c], [r, c]])
+        
+        heapq.heapify(pq)
+        
+        uf = Union_Find(N)
+        while not uf.connected(start, goal):
+            t, coord = heapq.heappop(pq)
+            r, c = coord
+            is_activated[r][c] = True
+            for dy, dx in move:
+                nr, nc = r+dy, c+dx
+                if is_valid_coord(nr, nc) and is_activated[nr][nc]:
+                    uf.union([r, c], [nr, nc])
+        
+        return t


### PR DESCRIPTION
## 문제

(https://leetcode.com/problems/swim-in-rising-water/)

## 개요

- n * n 크기의 정수 배열 grid가 주어진다. 배열의 각 값은 해당 좌표의 해발고도(elevation)를 나타낸다.
    - 0 ≤ i, j< n인 grid[i][j]에 대하여, 0 ≤ grid[i][j] < n^2이며, 중복되는 값은 없다.
- 시간을 t라고 할 때, 시간 t에는 배열 내에서 t보다 작거나 같은 값을 가지는 곳만 지나갈 수 있게 된다. 동서남북 4방향으로 인접한 칸에 대해 이동이 가능하며, 이동 중 배열 밖으로 나가는 것은 허용되지 않는다.
- grid[0][0]에서 출발하여 grid[n-1][n-1]까지 도달 가능한 최소의 시간을 리턴한다.
    - 이동에 걸리는 시간은 계산하지 않는다.

## 초기 설계

- 이 문제에서는 시간 값이 커짐에 따라 지나갈 수 있는 칸이 점점 늘어난다. 각 시간에 새로 지나갈 수 있게 되는(활성화되는) 칸을 표시하고, 표시된 칸들만 보았을 때 grid[0][0]과 grid[n-1][n-1]이 연결되기 시작하는 최초의 시간을 리턴하면 될 것 같다.
- 시작 지점과 도착 지점의 연결 여부를 매번 탐색하지 않고 확인할 수 있을까?
    - Union-find : 시간을 1씩 증가시키며 시간이 증가할 때마다 직접 연결되는(=동서남북 4방향으로 인접한) 칸들끼리 union을 수행한다. 이 과정을 grid[0][0]과 grid[n-1][n-1]이 같은 그룹에 속할 때까지 반복한다.
    - 칸이 활성화되자마자 union을 수행하면 실제로는 연결되어 있지 않은 칸들이 같은 그룹에 속하게 되므로, grid[0][0]과 grid[n-1][n-1]이 모두 활성화되자마자 연결 여부와 상관없이 종료되는 문제점이 있다. 시간이 증가할 때마다 새로이 활성화되는 칸(grid[r][c])의 인접한 4칸(grid[nr][nc])의 활성화 여부를 검사, 인접한 칸이 활성화되어 있으면 해당 칸과 grid[r][c]에 대해 union을 수행한다.
        - is_activated(List(bool)) : 칸의 활성화 여부를 저장
- 새로 활성화되는 칸을 찾을 때 배열 전체를 순회하며 값이 t인 칸을 찾는 것은 너무 비효율적이다. 좋은 방법이 있을까?
    - 딕셔너리 활용 : elevation_map[grid[r][c]] = [r, c] → t값을 1씩 증가시키며 딕셔너리에서 값이 t인 칸의 좌표를 얻음
    - heap(priority queue) 활용 : pq.append([grid[r][c], [r, c]]) → heapq.heapify(pq) / 큐에서 꺼낼 때마다 얻은 칸 값을 시간으로 사용

## 어려움을 겪은 내용 & 해결 방법

### 1. 2차원 배열에 대한 Union-find 코드 작성

지금까지 풀어본 Union-find 사용 가능한 문제들은 문제에 주어지는 조건을 1차원 배열로 쉽게 환산 가능했기 때문에, 해당 알고리즘을 사용할 수 있다는 사실만 알아내면 코드를 작성하는 것 자체는 그렇게 어렵지 않았다.

그러나 이 문제의 경우 Union-find 내부에서 1차원 배열을 쓰려면 2차원 좌표값을 1차원 형태로 변형하는 계산을 거쳐야 한다.

처음 코드를 작성할 때는 좌표값 변형 계산을 거치면 인접 셀 찾기와 유효한 범위 확인 작업이 복잡해질 것이라고 생각하여 Union-find 내부를 2차원 배열을 다룰 수 있도록 작성하였다. 중점적으로 변형한 부분은 아래와 같다.

```python
class Union_Find:
    def __init__(self, size: int) -> None:
        **self.root = [[[r, c] for c in range(size)] for r in range(size)]**
        self.rank = [[1] * size for _ in range(size)]
        
    def find(self, **x: List[int]) -> List[int]:**  # x: [r, c]
        r, c = x
        if x == self.root[r][c]:
            return x
        self.root[r][c] = self.find(self.root[r][c])
        return self.root[r][c]
...
```

- 그룹의 대표값을 표현하는 배열 root를 2차원 배열로 선언하고, 각 셀은 리스트 형태의 2차원 좌표를 저장하도록 하였다. root[r][c]의 값은 좌표 [r, c]가 속하는 그룹의 대표 좌표를 나타낸다.
- 인자로 받은 대상이 속하는 그룹의 대표값을 반환하는 find 함수가 리스트 형태의 2차원 좌표 형태를 입력으로 받고, 출력값도 같은 형태로 반환하도록 하였다.

Union-find 내부 저장 및 기본적인 계산은 1차원 기준으로 하도록 하고 인접 셀 관련 연산을 수행할 때에만 2차원 좌표로 환산하여 계산하는 방식도 가능할 것 같다.

## 다른 풀이

### 🟩 Binary Search

이 문제의 특성을 다시 살펴보자.

- grid[0][0]에서 grid[n-1][n-1]까지 도달하는 길이 처음으로 연결되기 전까지는 절대로 도달할 수 없고, 한번 연결된 이후에는 언제나 도달 가능하다. 답이 이분적 특성을 가지므로 binary search를 활용할 수 있다.
    - t의 범위가 [lo, … , hi]일 때, 질문을 “시간이 [lo, … , hi]일 때, grid[0][0]에서 grid[n-1][n-1]까지 가는 길이 열려있는가?”로 만들 수 있다. 이에 대한 답은 [F, …, F, T, …, T] 형태가 되며, 목표는 답이 T가 되게 하는 가장 작은 t값이다(lower bound).
- 0 ≤ i, j< n인 grid[i][j]에 대하여, 0 ≤ grid[i][j] < n^2이므로, t < 0인 경우는 고려할 필요가 없으며, t ≥ (n^2-1)이면 모든 칸을 지나갈 수 있다.
    - Search space를 0 ≤ t < (n^2-1)로 할 수 있다(lo = 0, hi = n^2-1).
    

하한과 상한(lo, hi)의 평균(mid)을 정답으로 가정하고, grid[0][0]에서 출발하여 값이 mid 이하인 칸만을 지나 grid[n-1][n-1]에 도달 가능한지를 dfs/bfs로 알아낸다(작성한 코드에서는 bfs 이용).

t = mid라고 가정했을 때 도달 가능할 경우, 이 값은 정답 구간에 포함되지만 더 작은 t값이 있을 수 있다. 따라서, 다음 search space에 mid를 포함하면서 작은 쪽으로 좁힌다(hi = mid)

도달 불가능할 경우, 이 값은 정답 구간에 불포함되며 t는 mid보다 큰 쪽에 있을 것이다. 따라서, 다음 search space에 mid를 제외하면서 큰 쪽으로 좁힌다(lo = mid + 1)

이 과정을 반복하면서 search space를 반씩 줄여 답을 찾는다.

작성한 코드는 다음과 같다.

```python
class Solution:
    def swimInWater(self, grid: List[List[int]]) -> int:
        
        def is_valid_coord(r: int, c: int) -> bool:
            return 0 <= r < N and 0 <= c < N
        
        def bfs(start: List[int], goal: List[int], t: int) -> bool:
            q = collections.deque()
            visited = [[False] * N for _ in range(N)]
            
            q.append(start)
            sr, sc = start
            visited[sr][sc] = True
            while q:
                r, c = q.popleft()
                for dy, dx in move:
                    nr, nc = r+dy, c+dx
                    if is_valid_coord(nr, nc) and grid[nr][nc] <= t and not visited[nr][nc]:
                        q.append((nr, nc))
                        visited[nr][nc] = True
            
            gr, gc = goal
            return True if visited[gr][gc] else False

        
        N = len(grid)
        start = (0, 0)
        goal = (N-1, N-1)
        move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
        
        lo, hi = 0, N**2 - 1
        while lo < hi:
            mid = (lo + hi) // 2
            if grid[0][0] > mid or grid[N-1][N-1] > mid:
                lo = mid + 1
                continue
            
            if bfs(start, goal, mid):
                hi = mid
            else:
                lo = mid + 1
        
        return hi
```