### PR TITLE
[16주차] 김준근-programmers-72414

### DIFF
--- a/programmers/72414/김준근.py
+++ b/programmers/72414/김준근.py
@@ -1,0 +1,53 @@
+def convert_time(time_string):
+    hour, minute, second = map(int, time_string.split(":"))
+    return hour * 3600 + minute * 60 + second
+
+
+def convert_format_time(time):
+    hour = ("0" + str(time // 3600))[-2:]
+    time %= 3600
+    minute = ("0" + str(time // 60))[-2:]
+    second = ("0" + str(time % 60))[-2:]
+    return ":".join([hour, minute, second])
+
+
+def convert_logs(logs):
+    start_times = []
+    end_times = []
+
+    for log in logs:
+        start, end = log.split("-")
+        start = convert_time(start)
+        end = convert_time(end)
+        start_times.append(start)
+        end_times.append(end)
+    return sorted(start_times), sorted(end_times)
+
+
+def solution(play_time, adv_time, logs):
+    play_time = convert_time(play_time)
+    adv_time = convert_time(adv_time)
+    view_counts = [0 for _ in range(play_time)]
+    start_times, end_times = convert_logs(logs)
+    start_index = 0
+    end_index = 0
+    for i in range(play_time):
+        while start_index < len(start_times) and start_times[start_index] == i:
+            view_counts[i] += 1
+            start_index += 1
+        while end_index < len(end_times) and end_times[end_index] == i:
+            view_counts[i] -= 1
+            end_index += 1
+        if i > 0:
+            view_counts[i] += view_counts[i - 1]
+
+    view_time = sum(view_counts[:adv_time])
+    max_length = view_time
+    answer = 0
+    for current_time in range(adv_time, play_time):
+        view_time -= view_counts[current_time - adv_time]
+        view_time += view_counts[current_time]
+        if max_length < view_time:
+            answer = current_time - adv_time + 1
+            max_length = view_time
+    return convert_format_time(answer)


### PR DESCRIPTION
## 문제

https://programmers.co.kr/learn/courses/30/lessons/72414

### 틀린 풀이

시간이 최대 99시간 59분 59초로 360000초 까지 밖에 없다는 것을 인지했지만, 모든 로그를 360000크기의 배열에 값을 더해주는 것은 360000 * 300000 라는 시간복잡도가 발생할 것으로 보여 이 방법을 사용하지 않았다.

그래서 처음에는 로그들을 시작시간으로 정렬하여 시작 시간마다 누적 재생시간을 계산했는데 이 방법은 누적 재생시간을 매번 새로 계산해야돼서 시간 초과가 발생헀다.

### 맞는 풀이

결국 다른 사람 풀이를 봤는데, 처음에 언급한 방법을 활용하는 것이었다. 모든 로그들을 시작 시간과 종료 시간 두 배열로 나눠서 정렬하고, 360000크기의 배열을 돌면서 해당 시간에 시작하는 사람이 있으면 +1, 끝나는 사람이 있으면 -1을 해주면서 앞의 배열에서 누적시켜주면 된다. 이렇게 하면 360000 + 300000 라는 시간복잡도가 발생하므로 시간 초과가 발생하지 않는다.

## 참고 자료

https://tech.kakao.com/2021/01/25/2021-kakao-recruitment-round-1/#문제-5-광고-삽입