### PR TITLE
[16주차] yyj-Leetcode-32

### DIFF
--- a/Leetcode/32/yyj.py
+++ b/Leetcode/32/yyj.py
@@ -1,0 +1,31 @@
+class Solution:
+    def longestValidParentheses(self, s: str) -> int:
+        N = len(s)
+        left_p, right_p = '(', ')'
+        res = 0
+        left, right = 0, 0
+        
+        for p in s:
+            if p == left_p:
+                left += 1
+            elif p == right_p:
+                right += 1
+            
+            if left == right:
+                res = max(res, left * 2)
+            elif left < right:
+                left, right = 0, 0
+        
+        left, right = 0, 0
+        for p in reversed(s):
+            if p == left_p:
+                left += 1
+            elif p == right_p:
+                right += 1
+            
+            if left == right:
+                res = max(res, left * 2)
+            elif left > right:
+                left, right = 0, 0
+                
+        return res


### PR DESCRIPTION
## 문제

[https://leetcode.com/problems/longest-valid-parentheses/](https://leetcode.com/problems/longest-valid-parentheses/)

## 개요

- ‘(’와 ‘)’로만 이루어진 문자열 s가 주어진다.
- 주어진 문자열 내에서 연속되어 있으면서 유효한 괄호인 부분 문자열 중 가장 긴 것의 길이를 리턴한다.
    - 유효한 괄호 : 모든 ‘(’의 오른편에 대응되는 ‘)가 있다.

## 초기 설계

- 이 문제는 단순 선형탐색 1회로는 풀 수 없는 문제이다. 어떤 ‘(’을 발견했을 때 오른편 어딘가에 이와 대응되는 ‘)’가 있을지는 실제로 오른편을 봐야 알 수 있기 때문이다.
    - 이런 문제를 풀 때 가장 직관적으로 떠오르는 자료구조는 스택이다. 지나온 길을 되돌아가며 조건에 맞게 되었는지 살펴볼 수 있는 스택의 특성을 이용해보자.
- 문자열 s의 각 문자를 순회하면서 스택에 문자를 삽입한다. 현재 문자가 ‘)’라면, 스택의 맨 위와 비교하여 유효한 괄호가 만들어질 때에만 스택에 넣었던 문자를 pop하도록 한다.

## 어려움을 겪은 내용 & 해결 방법

### 1. 연속한 유효 괄호의 길이 계산

s = “)(()()))()))(”인 경우를 생각해보자.

※ 서술 참고사항

- 각 문자의 인덱스와 실제 문자는 [index, parentheses] 형식으로 기술한다.
- 서로 매칭되어 스택에서 빠진 문자의 쌍은 {[l_index, '('], [r_index, ')']} 형식으로 기술한다.

[1, ‘( ‘]는 {[2, ‘(’], [3, ‘)’]}과 {[4, ‘(’], [5, ‘)’]}가 매칭된 후, [6, ‘)’]를 만났을 때 매칭될 수 있다. 이 사실은 [6, ‘)’]을 탐색하기 이전에는 알 수 없다.

정방향으로 탐색하는 동안 이전의 모든 정보를 누적하여 비교하지 않아도 일정한 조건에 도달했을 때 돌아가서 살펴볼 수 있는 것이 스택의 장점이다. 따라서, ‘유효한 괄호의 길이’를 계산하는 데 가장 중요한 정보인 ‘각 문자의 index’를 스택에 함께 저장해 두는 편이 좋을 것이다.

스택에서 괄호를 꺼낼 때마다 지금까지 찾아낸 최대 길이와 (r_index - l_index + 1) 값을 비교하여 갱신하면 될 것이라고 생각했지만 문제가 있었다. 이 방법을 사용하면 s=’()()’의 실제 정답은 4이지만, {[0, ‘(’], [1, ‘)’]}가 매칭되어 길이 2, {[2, ‘(’], [3, ‘)’]}가 매칭되어 길이 2로 답이 2가 나온다.

interval 리스트를 따로 만들어 괄호를 스택에서 꺼낼 때마다 interval = [[2,3],[4,5]]와 같이 저장해두고 연속되는 구간이면 합치는 방법을 생각해 봤는데, 구현이 너무 복잡할 것 같았다.

추가 저장 공간을 쓰지 않는 방법이 생각나지 않아 길이 len(s), 기본값 0인 matched 배열을 만들고, 괄호가 매칭될 때마다 matched[l_index], matched[r_index] 값을 1로 만들어 주었다. 문자열 순회를 끝낸 다음, matched 배열에서 1이 가장 길게 연속되는 횟수를 찾아 리턴하였다.

작성한 코드는 다음과 같다.

```python
class Solution:
    def longestValidParentheses(self, s: str) -> int:
        stack = []
        N = len(s)
        left_p, right_p = '(', ')'
        matched = [0] * N
        res = 0
        
        for i, p in enumerate(s):
            if not stack or p == left_p:
                stack.append([i, p])
            else:
                if stack[-1][1] == left_p and p == right_p:
                    si, sp = stack.pop()
                    matched[si] = 1
                    matched[i] = 1
                else:
                    stack.append([i, p])
        
        res = 0
        cnt = 0
        for i, valid in enumerate(matched):
            if valid:
                cnt += 1                
            if not valid or i == N-1:
                res = max(res, cnt)
                cnt = 0
                    
        return res
```

## 다른 풀이

### 🟩 Scan twice, using two counters

이 문제의 중요한 특징은 ‘현재 원소가 유효한 부분 문자열의 member가 될 수 있는지는 현재 탐색 중인 방향으로 탐색을 계속하다 보면 결정된다’는 점에 있다.

이러한 경우, 정방향 탐색과 역방향 탐색을 수행한 후 각 탐색에서 얻어낸 값의 최대/최소나 공통부분을 취하는 방식으로 답을 얻을 수 있다.

이 문제에서는 int형 변수 2개(left, right)를 카운터로 사용하여 문자열 s를 순회하면서 괄호의 방향에 따라 카운터를 증가시키고, left == right일 때 유효한 괄호의 최대 길이를 갱신한다.

만약 어떤 괄호를 발견함으로써 선행 괄호보다 후행 괄호가 많아진다면(정방향 탐색일 경우 ‘)’, 역방향 탐색일 경우 ‘(’) 이 괄호는 유효한 연속 괄호에 포함될 수 없다. 열리지 않았는데 괄호를 닫은 셈이기 때문이다. 연속성이 끊어졌으므로, 카운터를 초기화하면 된다.

작성한 코드는 다음과 같다.

```python
class Solution:
    def longestValidParentheses(self, s: str) -> int:
        N = len(s)
        left_p, right_p = '(', ')'
        res = 0
        left, right = 0, 0
        
        # 1st scan: left to right
        for p in s:
            if p == left_p:
                left += 1
            elif p == right_p:
                right += 1
            
            if left == right:
                res = max(res, left * 2)
            # if ')' appears without preceeding '('
            # it cannot be member of valid candidates, so counters should be initialized
            elif left < right:
                left, right = 0, 0
        
        # 2nd scan: right to left
        left, right = 0, 0
        for p in reversed(s):
            if p == left_p:
                left += 1
            elif p == right_p:
                right += 1
            
            if left == right:
                res = max(res, left * 2)
            elif left > right:
                left, right = 0, 0
                
        return res
```