### PR TITLE
[16주차] ygg-Leetcode-2289

### DIFF
--- a/Leetcode/2289/ygg.py
+++ b/Leetcode/2289/ygg.py
@@ -1,0 +1,85 @@
+def totalSteps(self, nums: list[int]) -> int:
+    if len(nums) <= 1:
+        return 0
+
+    """
+    # TLE
+    popped = False
+    step = 0
+    while True:
+        i = 1
+        prev = nums[0]
+        while i < len(nums):
+            if nums[i] < prev:
+                prev = nums.pop(i)
+                popped = True
+            else:
+                prev = nums[i]
+                i += 1
+        # print(nums, popped)
+        if popped:
+            popped = False
+            step += 1
+        else:
+            break
+
+    return step
+    """
+
+    """
+    # try 1. calc max step & linear
+    max_step = 0
+
+    i = 1
+    prev = nums[0]
+    while i < len(nums):
+        if nums[i] < prev:
+            step = 1
+            prev = nums.pop(i)
+            # try 1.2. [5,14,15,"2,11,5,13",15]
+            # try 1.3. [1945, 1886, 346, 481, 1059, 1388, 1483, 1516, 1842, 1868, 1877, 398, 907, 995, 1167, 1214, 1423, 1452, 1464, 1474, 1311, 1427, 1757, 1992]
+            prev_step = 1
+            prev_max = prev
+            while i < len(nums) and nums[i - 1] > nums[i]:
+                if prev_max <= nums[i]:
+                    step = max(prev_step, step) + 1
+                    prev_max = nums[i]
+                elif prev <= nums[i]:
+                    step += 1
+                # try 1.1. [10,1,2,3,4,5,6,"1,2,3"]
+                else:
+                    if step > prev_step:
+                        prev_max = prev
+                    elif step == prev_step:
+                        prev_max = min(prev_max, prev)
+                    print(nums, step, prev_step, prev_max)
+                    max_step = max(step, max_step)
+                    prev_step = max(step, prev_step)
+                    step = 1
+                prev = nums.pop(i)
+            max_step = max(step, prev_step)
+            # print(nums, step, max_step)
+        else:
+            prev = nums[i]
+            i += 1
+
+    return max_step
+    """
+
+    # try 2. multi stack
+    ans = 0
+    stacks = [[nums[0], 0]]
+
+    for n in nums[1:]:
+        m = 0
+        while stacks and stacks[-1][0] <= n:
+            v, s = stacks.pop()
+            m = max(s, m)
+        if stacks:
+            m += 1
+        else:
+            m = 0
+        stacks.append([n, m])
+        ans = max(ans, m)
+
+    return ans


### PR DESCRIPTION
## 문제
https://leetcode.com/contest/weekly-contest-295/problems/steps-to-make-array-non-decreasing/
주어진 배열을 감소하지 않는 배열로 만들 때 필요한 step 수
단, 각 step 마다 인접한 원소 하나씩 만을 지움

## 어려움을 겪은 내용
매 step 마다 주어진 내용을 직접 수행 → TLE
최적화 시도
1. 같거나 더 높은 수가 등장하기 전까지 step을 직접 계산
   - 이전에 발견된 가장 큰 수보다 작은 수의 개수 세기
   - 반례: [10,1,2,3,4,5,6,"1,2,3"] → 뒤의 3 숫자는 앞에 6개를 처리하는 step 내에서 완료되므로 세지 않아야 함
2. 현재 가장 큰 수 외에 이전 step 내에서 가장 컸던 수를 저장
   - 앞의 사례에서 6을 저장해두고 1~3까지는 빼주기
   - 추가사례1: [5,14,15,"2,11,5,13",15] → 13을 연속으로 셀 수 있도록 이전 step에서 이어지는 if문 추가
   - 추가사례2: [1945, 1886, 346, 1059, 1483, 1842, 1877, 398, 995, 1214, 1452, 1474, 1311, 1427, 1757, 1992] → 뒤에 나오는 step의 수가 더 클 경우 이전 step 정보 update
3. 문제 발견
   - 추가사례1/2가 복합으로 등장할 경우 단순 이전 step 정보 하나만으로는 커버 불가능

## 해결 방법
최적화 방법 변경: 여러 개의 top을 stack 화
![image](https://user-images.githubusercontent.com/16753880/171461986-37e91d57-1f68-41e8-b6c2-cac682b1ee7b.png)
![image](https://user-images.githubusercontent.com/16753880/171462030-d74f69d1-7cb5-49cf-8733-3c9af247c392.png)

