### PR TITLE
[17주차] yyj-Leetcode-1368,2290

### DIFF
--- a/Leetcode/1368, 2290/yyj_1368_01bfs.py
+++ b/Leetcode/1368, 2290/yyj_1368_01bfs.py
@@ -1,0 +1,28 @@
+class Solution:
+    def minCost(self, grid: List[List[int]]) -> int:
+        
+        def is_valid_coord(r: int, c: int) -> bool:
+            return 0 <= r < M and 0 <= c < N
+        
+        M, N = len(grid), len(grid[0])
+        dist = [[math.inf] * N for _ in range(M)]
+        deque = collections.deque()
+        move = {1: (0, 1), 2: (0, -1), 3: (1, 0), 4: (-1, 0)}
+        
+        dist[0][0] = 0
+        deque.appendleft( [dist[0][0], 0, 0, grid[0][0]] )
+        
+        while deque:
+            cost, r, c, direction = deque.popleft()
+            for d in move:
+                dy, dx = move[d]
+                nr, nc = r+dy, c+dx
+                expense = 0 if d == direction else 1
+                if is_valid_coord(nr, nc) and dist[r][c] + expense < dist[nr][nc]:
+                    dist[nr][nc] = dist[r][c] + expense
+                    if not expense:
+                        deque.appendleft( [dist[nr][nc], nr, nc, grid[nr][nc]] )
+                    else:
+                        deque.append( [dist[nr][nc], nr, nc, grid[nr][nc]] )
+                        
+        return dist[M-1][N-1]

--- a/Leetcode/1368, 2290/yyj_1368_priorityqueue.py
+++ b/Leetcode/1368, 2290/yyj_1368_priorityqueue.py
@@ -1,0 +1,28 @@
+class Solution:
+    def minCost(self, grid: List[List[int]]) -> int:
+        
+        def is_valid_coord(r: int, c: int) -> bool:
+            return 0 <= r < M and 0 <= c < N
+        
+        M, N = len(grid), len(grid[0])
+        pq = []
+        move = {1: (0, 1), 2: (0, -1), 3: (1, 0), 4: (-1, 0)}
+        dist = [[math.inf] * N for _ in range(M)]
+        
+        dist[0][0] = 0
+        heapq.heappush(pq, [dist[0][0], 0, 0, grid[0][0]])
+        
+        while pq:
+            cost, r, c, direction = heapq.heappop(pq)
+            if r == M-1 and c == N-1:
+                return cost
+            
+            for mv in move:
+                expense = 0 if direction == mv else 1
+                dy, dx = move[mv]
+                nr, nc = r+dy, c+dx
+                if is_valid_coord(nr, nc) and cost + expense < dist[nr][nc]:
+                    dist[nr][nc] = cost + expense
+                    heapq.heappush(pq, [cost + expense, nr, nc, grid[nr][nc]])
+                    
+        return dist[M-1][N-1]

--- a/Leetcode/1368, 2290/yyj_2290_01bfs.py
+++ b/Leetcode/1368, 2290/yyj_2290_01bfs.py
@@ -1,0 +1,26 @@
+class Solution:
+    def minimumObstacles(self, grid: List[List[int]]) -> int:
+        
+        def is_valid_coord(r: int, c: int) -> bool:
+            return 0 <= r < M and 0 <= c < N
+        
+        M, N = len(grid), len(grid[0])
+        deque = collections.deque()
+        min_cost = [[math.inf] * N for _ in range(M)]
+        move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        
+        min_cost[0][0] = 0
+        deque.appendleft( [0, 0, min_cost[0][0]] )
+        
+        while deque:
+            r, c, cost = deque.popleft()
+            for dy, dx in move:
+                nr, nc = r+dy, c+dx
+                if is_valid_coord(nr, nc) and cost + grid[nr][nc] < min_cost[nr][nc]:
+                    min_cost[nr][nc] = cost + grid[nr][nc]
+                    if not grid[nr][nc]:
+                        deque.appendleft( [nr, nc, min_cost[nr][nc]] )
+                    else:
+                        deque.append( [nr, nc, min_cost[nr][nc]] )
+                            
+        return min_cost[M-1][N-1]

--- a/Leetcode/1368, 2290/yyj_2290_priorityqueue.py
+++ b/Leetcode/1368, 2290/yyj_2290_priorityqueue.py
@@ -1,0 +1,22 @@
+class Solution:
+    def minimumObstacles(self, grid: List[List[int]]) -> int:
+        def is_valid_coord(r: int, c: int) -> bool:
+            return 0 <= r < M and 0 <= c < N
+        
+        M, N = len(grid), len(grid[0])
+        pq = []
+        min_cost = [[math.inf] * N for _ in range(M)]
+        move = [(0, 1), (1, 0), (0, -1), (-1, 0)]
+        
+        min_cost[0][0] = 0
+        heapq.heappush( pq, [min_cost[0][0], 0, 0] )  
+        
+        while pq:
+            cost, r, c = heapq.heappop(pq)
+            for dy, dx in move:
+                nr, nc = r+dy, c+dx
+                if is_valid_coord(nr, nc) and cost + grid[nr][nc] < min_cost[nr][nc]:
+                    min_cost[nr][nc] = cost + grid[nr][nc]
+                    heapq.heappush( pq, [min_cost[nr][nc], nr, nc] )
+                            
+        return min_cost[M-1][N-1]


### PR DESCRIPTION
## 문제

1368 (https://leetcode.com/problems/minimum-cost-to-make-at-least-one-valid-path-in-a-grid/)
2290 (https://leetcode.com/problems/minimum-obstacle-removal-to-reach-corner/)

## 개요

- m * n 크기의 배열 grid가 주어진다. 각 셀의 숫자는 해당 셀에서 이동할 방향을 지시한다.
    - 현재 셀의 숫자가 나타내는 방향에 인접한 셀로 이동하게 되며, 이동 비용은 없다.
    - 1 : 오른쪽, 2 :  왼쪽, 3 : 위, 4 : 아래
    - 배열 바깥으로 이동하는 방향 지시가 존재할 수 있다.
- 현재 셀의 숫자(이동할 방향)을 다른 것으로 바꾸어 이동할 수 있으며, 변경하여 이동할 때 비용은 1이다. 한 번 변경한 셀은 다시 변경할 수 없다.
- 출발지가 grid[0][0]이고 도착지가 grid[m-1][n-1]일 때, 유효한 경로를 만들 수 있는 가장 적은 변경 비용을 리턴한다.

## 초기 설계

- 각 셀에서 상하좌우 방향으로 인접한 모든 셀로 이동하면서 비용을 계산한다. 출발지에서 현제 셀 (r, c)와 인접한 셀 (nr, nc)까지의 비용은 주어진 방향으로(셀 값대로) 이동할 때에는 출발지에서 현재 셀까지의 비용에 0을 더하고, 주어진 방향과 다르게 이동할 때에는 1을 더하여 계산한다.
- 탐색은 priority queue(minheap)를 사용한다. 이는 출발지로부터의 이동 비용이 가장 적은 셀을 고를 수 있게 해준다.
    - 저장하는 정보 : 출발지로부터 현재 셀까지의 거리, 현재 셀의 좌표, 현재 셀에서 다음 셀로 이동할 때 지정된 방향
- 이미 방문한 셀을 표시하기 위해 visited(set)을 사용한다.

## 어려움을 겪은 내용 & 해결 방법

### 1. 우선순위 큐에 불필요한 원소 저장

아래 코드는 크기가 작은 데이터에 대해서는 잘 작동하지만, 데이터의 크기가 커지면 TLE를 받는다.

```python
class Solution:
    def minCost(self, grid: List[List[int]]) -> int:
        
        def is_valid_coord(r: int, c: int) -> bool:
            return 0 <= r < M and 0 <= c < N
        
        M, N = len(grid), len(grid[0])
        pq = []     # [cost, r, c, direction]
        move = {1: (0, 1), 2: (0, -1), 3: (1, 0), 4: (-1, 0)}
        visited = set()
        
        heapq.heappush(pq, [0, 0, 0, grid[0][0]])
        
        while pq:
            cost, r, c, direction = heapq.heappop(pq)
            visited.add((r, c))
            if r == M-1 and c == N-1:
                return cost
            
            # original
            dy, dx = move[direction]
            nr, nc = r+dy, c+dx
            if is_valid_coord(nr, nc) and (nr, nc) not in visited:
                heapq.heappush(pq, [cost, nr, nc, grid[nr][nc]])
                
            # change
            for mv in move:
                if direction == mv:
                    continue
                dy, dx = move[mv]
                nr, nc = r+dy, c+dx
                if is_valid_coord(nr, nc) and (nr, nc) not in visited:
                    heapq.heappush(pq, [cost+1, nr, nc, grid[nr][nc]])
```

우선순위 큐를 사용하므로 정렬 비용이 O(logN)으로 크지 않고 큐를 다 비우지 않아도 (M-1, N-1)을 만나면 종료하므로 비용 처리를 큐로만 해도 상관없을 것이라고 생각했었다.

그러나 우선순위 큐가 비거나 (M-1, N-1)에 도달할 때까지 pop과 탐색 여부 결정을 계속해야 하고, 큐에 들어있는 원소가 많을수록 최소 힙의 구조를 유지하는 비용도 커진다. 따라서, 살펴볼 가치가 없는 원소를 큐에 저장하는 것은 낭비이다.

위 코드에는 어떤 셀에 대하여 출발지로부터 그 셀까지의 이동 비용이 이전에 탐색한 것보다 적어졌는지 검사하는 부분이 없다. 이 부분을 추가하려면 지금까지 찾은 출발지로부터 각 셀까지의 이동 비용을 저장할 캐시도 필요하다

- dist(2차원 int 배열) : 크기 M * N, 출발지로부터 각 셀까지의 이동 비용을 저장함, 출발지는 0, 나머지는 inf로 초기화
- 현재 셀을 (r, c), 이동할 셀을 (nr, nc)라고 할 때, (출발지로부터 (r, c)까지의 최단거리) + ((r, c) → (nr, nc) 이동비용) < (현재까지 발견한 출발지로부터 (nr, nc) 까지의 최단거리)이면 dist[nr][nc]를 갱신하고 우선순위 큐에 삽입한다.

주어진 방향대로 이동하는 경우 / 방향을 바꾸어 이동하는 경우를 구분할 필요 없이 하나의 for문으로 처리가 가능하다는 것을 발견하여 다음 셀 탐색 부분도 수정하였다.

수정한 코드는 다음과 같다.

```python
class Solution:
    def minCost(self, grid: List[List[int]]) -> int:
        
        def is_valid_coord(r: int, c: int) -> bool:
            return 0 <= r < M and 0 <= c < N
        
        M, N = len(grid), len(grid[0])
        pq = []
        move = {1: (0, 1), 2: (0, -1), 3: (1, 0), 4: (-1, 0)}
        dist = [[math.inf] * N for _ in range(M)]
        
        dist[0][0] = 0
        heapq.heappush(pq, [dist[0][0], 0, 0, grid[0][0]])
        
        while pq:
            cost, r, c, direction = heapq.heappop(pq)
            if r == M-1 and c == N-1:
                return cost
            
            for mv in move:
                expense = 0 if direction == mv else 1
                dy, dx = move[mv]
                nr, nc = r+dy, c+dx
                if is_valid_coord(nr, nc) and cost + expense < dist[nr][nc]:
                    dist[nr][nc] = cost + expense
                    heapq.heappush(pq, [cost + expense, nr, nc, grid[nr][nc]])
                    
        return dist[M-1][N-1]
```

### 2. visited set 사용 여부

다익스트라 알고리즘의 정의에 따라, 큐에서 꺼낸 셀은 출발지로부터 그 셀까지의 최단 거리가 발견된 상태임이 보장된다.

우선순위 큐에서 꺼낸 현재 셀을 (r, c), 이동할 셀을 (nr, nc)라고 할 때, (출발지로부터 (r, c)까지의 최단거리) + ((r, c) → (nr, nc) 이동비용) < (현재까지 발견한 출발지로부터 (nr, nc) 까지의 최단거리)일 때에만 (nr, nc)가 탐색 대상이 되어 우선순위 큐에 삽입된다.

따라서, (r, c)가 우선순위 큐에서 꺼내어져 방문된 이후, 큐에서 꺼내어져 방문된 (fr, fc)의 인접한 셀 중 (r, c)가 있더라도, (r, c)는 이전 방문 때 이미 최단거리가 발견된 상태이므로 다시 탐색 대상이 되지 않음이 보장된다.

이와 같은 경우 visited set을 사용하지 않아도 큐에서 같은 셀을 두 번 이상 꺼내는 일이 없다.

### 3. 시력 테스트

이동 방향을 쉽게 다루기 위해 방향을 나타내는 숫자를 key, 방향에 따른 좌표의 변화량을 value로 갖는 dictionary를 선언하였다.

```python
class Solution:
    def minCost(self, grid: List[List[int]]) -> int:
        ...
        move = {1: (0, 1), 2: (0, -1), 3: (0, 1), 4: (0, -1)}
        ...
```

샘플 테스트케이스로 시험할 때 한 테스트케이스에서 답이 None으로 나와 코드 로직을 여러 번 점검하였지만 무엇이 문제인지 알 수 없었다.

꽤 오랫동안 고민했는데 변화량을 잘못 쓰는 바람에 엉뚱한 방향으로 탐색이 진행되고 있었던 것이었다. 잘못된 부분을 찾을 때 너무 코드 로직에서만 찾으려고 하다가는 종종 이런 함정에 빠질 수 있다😅

~~2290번은 Weekly 4번으로 만난 문제인데, 1368번과 똑같은 문제인 것을 눈치챘으나 1368번의 TLE를 해결하지 못한 채 남겨둔 와중에 본 거라 2290번도 못풀었다 역대 하드 중 제일 쉬웠는데 이걸 놓치네 윽 제때 공부해라~~

## 다른 풀이

### 🟩 0-1 BFS

이 문제는 인접한 셀로 이동하는 비용이 항상 0 또는 1이라는 특징이 있다.
이 경우, deque(double-ended queue)를 사용하여 푸는 방법이 있다. 큐에는 항상 현재 셀과 비용이 같은 셀들과 현재 셀보다 비용이 1 큰 셀만 존재하기 때문이다.

인접한 셀의 비용이 갱신될 때, 출발지로부터 해당 셀에 도달하는 비용이 현재 셀과 같으면 deque의 앞쪽에, 현재 셀보다 1 크면 뒤쪽에 넣으면 우선순위 큐의 유지 비용 없이 우선순위 큐와 같은 효과를 볼 수 있다.

작성한 코드는 다음과 같다.

```python
class Solution:
    def minCost(self, grid: List[List[int]]) -> int:
        
        def is_valid_coord(r: int, c: int) -> bool:
            return 0 <= r < M and 0 <= c < N
        
        M, N = len(grid), len(grid[0])
        dist = [[math.inf] * N for _ in range(M)]
        deque = collections.deque()
        move = {1: (0, 1), 2: (0, -1), 3: (1, 0), 4: (-1, 0)}
        
        dist[0][0] = 0
        deque.appendleft( [dist[0][0], 0, 0, grid[0][0]] )
        
        while deque:
            cost, r, c, direction = deque.popleft()
            for d in move:
                dy, dx = move[d]
                nr, nc = r+dy, c+dx
                expense = 0 if d == direction else 1
                if is_valid_coord(nr, nc) and dist[r][c] + expense < dist[nr][nc]:
                    dist[nr][nc] = dist[r][c] + expense
                    if not expense:
                        deque.appendleft( [dist[nr][nc], nr, nc, grid[nr][nc]] )
                    else:
                        deque.append( [dist[nr][nc], nr, nc, grid[nr][nc]] )
                        
        return dist[M-1][N-1]
```