### PR TITLE
[18주차] SUB-baekjoon-11779

### DIFF
--- a/baekjoon/11779/SUB.py
+++ b/baekjoon/11779/SUB.py
@@ -1,0 +1,39 @@
+import heapq
+import sys
+
+n = int(input())
+m = int(input())
+
+arr = [[] for _ in range(n+1)]
+
+for _ in range(m):
+    start, end, cost = map(int, sys.stdin.readline().split())
+    arr[start].append([end, cost])
+
+start, end = map(int, input().split())
+
+dist = [n*100000+1 for _ in range(n+1)]
+path = [[] for _ in range(n+1)]
+path[start].append(start)
+q = []
+heapq.heapify(q)
+q.append([0, start])
+
+dist[start] = 0
+while q:
+    total, cur = heapq.heappop(q)
+    if total > dist[cur]:
+        continue
+    for next, next_cost in arr[cur]:
+        if next_cost + total < dist[next]:
+            dist[next] = next_cost + total
+            heapq.heappush(q, [next_cost + total, next])
+            path[next] = []
+            for p in path[cur]:
+                path[next].append(p)
+            path[next].append(next)
+dist[start] = 0
+
+print(dist[end])
+print(len(path[end]))
+print(' '.join(map(str,path[end])))


### PR DESCRIPTION
## 문제
<https://www.acmicpc.net/problem/11779>
## 해결 방법
우선순위 큐를 이용한 다익스트라 사용

heap에 삽입할 때, [거리, 노드번호] 순으로 삽입하여야 하는데, 반대로 삽입함

경로를 계산하는 부분에서 while문에서 발생한 무한루프 때문에 메모리 초과가 발생.
