### PR TITLE
[18주차] yyj-Leetcode-115

### DIFF
--- a/Leetcode/115/yyj.py
+++ b/Leetcode/115/yyj.py
@@ -1,0 +1,24 @@
+class Solution:
+    def numDistinct(self, s: str, t: str) -> int:
+        
+        def finder(ps: int, pt: int) -> int:
+            if pt == T:
+                return 1
+            if S-ps < T-pt:
+                return 0
+            
+            res = 0
+            for i in range(ps, S):
+                if s[i] == t[pt]:
+                    if (i+1, pt+1) not in cache:
+                        cases = finder(i+1, pt+1)
+                        cache[(i+1, pt+1)] = cases
+                    res += cache[(i+1, pt+1)]
+            
+            return res
+            
+        
+        S, T = len(s), len(t)
+        cache = {}
+        
+        return finder(0, 0)


### PR DESCRIPTION
## 문제

(https://leetcode.com/problems/distinct-subsequences/)

## 개요

- 영문자로 이루어진 두 문자열 s, t가 주어진다.
- 문자열 s로부터 얻을 수 있는 모든 부분 문자열 중 t와 같은 것의 개수를 리턴한다.
    - 부분 문자열은 각 문자의 상대적 위치를 바꾸지 않은 채로 원래 문자열에서 0개 이상의 문자를 지워서 얻을 수 있다. 원래 문자열이 “ABCDE”일 때, “ACE”는 원래 문자열의 부분 문자열이지만, “AEC”는 아니다.
    - 위치가 다른 문자를 사용한 경우 다른 문자열로 취급한다. “bbaag”에서 “bag”를 만들 때, [0, 2, 4]번째 문자를 이용하여 만든 것과 [1, 2, 4]번째 문자를 이용하여 만든 것은 구분하여 계산한다.

## 초기 설계

- S = len(s), T = len(t)
- finder(ps, pt) : 서로 다른 부분 문자열의 수를 계산하는 함수이다. ps는 문자열 s에서 , pt는 문자열 t에서 현재 확인 중인 문자의 인덱스이다.
    
    이 함수의 의미는 ‘s[ps:]로부터 얻을 수 있는 모든 부분 문자열 중 t[pt:]와 같은 것의 개수’이다. 즉, s[ps:], s[ps+1:], … , s[S]를 시작 문자로 하는 부분 문자열이 t[pt:]와 같게 되는 모든 경우의 수가 된다.
    
    이를 계산하기 위해 s[ps:]를 순회하면서 s[ps:]의 각 문자가 t[pt]와 같으면 다음에 확인할 인덱스를 넣어 재귀 호출한다(i+1, pt+1). pt == T이면 문자열 s에서 t의 모든 문자를 찾아낸 경우이므로 카운트한다.
    
    구하고자 하는 답은 문자열 s, t 전체에 대한 것이므로 finder(0, 0)으로 호출해 준다.
    

## 어려움을 겪은 내용 & 해결 방법

### 1. 시간 초과: Memoizaion & Optimization

아래 코드를 제출하면 시간 초과가 발생한다.

```python
class Solution:
    def numDistinct(self, s: str, t: str) -> int:
        
        def finder(ps: int, pt: int) -> int:
            if pt == T:
                return 1
            
            res = 0
            for i in range(ps, S):
                if s[i] == t[pt]:
                    res += finder(i+1, pt+1)
            
            return res
            
        
        S, T = len(s), len(t)
        
        return finder(0, 0)
```

재귀 호출을 하면서 중복되는 계산을 제거하지 않아 많은 중복 연산이 일어나고 있는 것으로 보인다. Memoization을 사용해 저장된 계산값이 있으면 가져다 쓰고, 최초로 계산하는 경우 계산한 결과를 저장하도록 하자.

수정된 코드는 다음과 같다.

```python
class Solution:
    def numDistinct(self, s: str, t: str) -> int:
        
        def finder(ps: int, pt: int) -> int:
            if pt == T:
                return 1
            
            res = 0
            for i in range(ps, S):
                if s[i] == t[pt]:
                    if (i+1, pt+1) not in cache:
                        cases = finder(i+1, pt+1)
                        cache[(i+1, pt+1)] = cases
                    res += cache[(i+1, pt+1)]
            
            return res
            
        
        S, T = len(s), len(t)
        cache = {}
        
        return finder(0, 0)
```

Memoization을 사용했음에도 len(s) = 1000, len(t) = 1000인 테스트케이스를 통과할 수 없었다. 제출에 대하여 시간초과가 발생할 뿐만 아니라, 해당 케이스 하나만 테스트해도 시간초과가 발생하였다. 계산을 줄일 수 있는 부분을 더 찾아보는 것이 좋겠다.

현재 함수의 종료 조건은 pt == T일 때이다. pt는 매칭되는 문자를 발견했을 때에만 1씩 증가하므로, 이는 t의 모든 문자를 찾았다는 의미가 된다. 이 경우는 실제로 t의 모든 문자를 발견해 보아야 확정할 수 있으므로 더 이상 줄일 여지는 없어 보인다.

t의 모든 문자를 찾지 못한 경우, pt == T가 되기 전에 ps == S가 되며 for문의 range 범위에 따라 함수가 종료될 것이다. 이렇게 될 것을 더 일찍 예측할 수 있을까? 만약 s[ps:]의 길이가 t[pt:]의 길이보다 짧아지면,  s[ps:]는 절대로 t[pt:]를 부분 문자열로 가질 수 없게 된다. 이 경우는 계속 탐색할 필요가 없으므로 탐색 중단 처리를 하도록 한다.
```python
class Solution:
    def numDistinct(self, s: str, t: str) -> int:
        
        def finder(ps: int, pt: int) -> int:
            if pt == T:
                return 1
            if S-ps < T-pt:
                return 0

    ...
```