### PR TITLE
[19주차] ygg-Leetcode-146

### DIFF
--- a/Leetcode/146/ygg.py
+++ b/Leetcode/146/ygg.py
@@ -1,0 +1,63 @@
+class Node:
+    def __init__(self, key, value, prev=None, next=None):
+        self.key = key
+        self.value = value
+        self.next = next
+        self.prev = prev
+
+
+class LRUCache:
+    def __init__(self, capacity: int):
+        self.capacity = capacity
+        self.cache = {}
+        self.head = Node(-1, -1)
+        self.tail = Node(-1, -1)
+        self.head.next = self.tail
+        self.tail.prev = self.head
+
+    def get(self, key: int) -> int:
+        if key in self.cache:
+            cur = self.cache[key]
+            cur.prev.next = cur.next
+            cur.next.prev = cur.prev
+            cur.prev = self.head
+            cur.next = self.head.next
+            self.head.next.prev = cur
+            self.head.next = cur
+            return cur.value
+        else:
+            return -1
+
+    def put(self, key: int, value: int) -> None:
+        # cur = self.head
+        # while cur.next:
+        #     print(cur.key, cur.value, cur.next.value)
+        #     cur = cur.next
+        # print("//")
+        # 2. updating value
+        # 3. update > recently used
+        if key in self.cache:
+            cur = self.cache[key]
+            cur.value = value
+            cur.prev.next = cur.next
+            cur.next.prev = cur.prev
+            cur.prev = self.head
+            cur.next = self.head.next
+            self.head.next.prev = cur
+            self.head.next = cur
+            return
+        if len(self.cache) >= self.capacity:
+            temp = self.tail.prev.prev
+            self.cache.pop(self.tail.prev.key)
+            self.tail.prev = temp
+            temp.next = self.tail
+        cur = Node(key, value, self.head, self.head.next)
+        self.cache[key] = cur
+        # 1. confused two lines
+        self.head.next.prev = cur
+        self.head.next = cur
+
+# Your LRUCache object will be instantiated and called as such:
+# obj = LRUCache(capacity)
+# param_1 = obj.get(key)
+# obj.put(key,value)


### PR DESCRIPTION
## 문제
https://leetcode.com/problems/lru-cache/
LRU cache의 개념적 구현

## 어려움을 겪은 내용
LRU cache 의 개념은 기억하였으나 원리를 까먹었다.
일단 찾아보지 않고 구현 시도
get()을 dictionary로 O(1) 처리하는 것까지는 생각했으나
put()을 O(1)로 처리할 방법이 떠오르지 않았음..

## 해결 방법
LRU의 개념도:
![image](https://user-images.githubusercontent.com/16753880/175098008-055c0f41-7bf9-4f44-b0c9-9a03551d05c5.png)

doubly linked list 활용하여 해결 가능
access (=get/put 두 행위 모두) 가 수행될 때마다 해당 node를 head.next로 옮김
put에서 새로운 node가 들어갈 자리가 없을 경우 tail.prev를 pop
dictionary에 단순 value가 아닌 linked list의 node를 넣어줌

