### PR TITLE
[20주차] yyj-Leetcode-2131

### DIFF
--- a/Leetcode/2131/yyj.py
+++ b/Leetcode/2131/yyj.py
@@ -1,0 +1,17 @@
+class Solution:
+    def longestPalindrome(self, words: List[str]) -> int:
+        N = len(words)
+        words_counter = collections.Counter(words)
+        two_same_letters_center = False
+        res = 0
+        
+        for w in words_counter:
+            if w[0] != w[1] and w[::-1] in words_counter:
+                res += 2 * min(words_counter[w], words_counter[w[::-1]])
+            elif w[0] == w[1]:
+                pair_count = 2 * (words_counter[w] // 2)
+                res += 2 * pair_count
+                if words_counter[w] > pair_count:
+                    two_same_letters_center = True
+        
+        return res if not two_same_letters_center else res + 2


### PR DESCRIPTION
## 문제

https://leetcode.com/problems/longest-palindrome-by-concatenating-two-letter-words/

## 개요

- 문자열을 원소로 갖는 배열 words가 주어진다. 이 배열의 원소는 모두 영문 소문자 2글자이다.
- 각 원소를 최대 한 번씩만 사용하여 배열에서의 순서와 상관없이 이어붙였을 때, 결과가 회문이 되는 경우 중 가장 긴 것의 길이를 리턴한다.

## 초기 설계

- 어떤 원소를 포함했을 때 회문이 되려면 그 원소를 뒤집은 원소가 배열에 있어야 한다.
    - words 배열을 이용하여 set 생성(words_set) - for O(1) search
    - words 배열의 모든 원소 w에 대하여, words_set에 w[::-1]이 존재하면 정중앙을 기준으로 같은 거리, 서로 반대편에 w와 w[::-1]을 각각 위치시켜 회문을 만들 수 있다.
    - 따라서, 위 경우 답(res)의 값을 2씩 증가시킨다. w와 w[::-1]의 총 길이가 4인데 4를 증가시키지 않는 이유는 words 배열을 순회하면서 w에 대응하는 w[::-1]에 대해서도 동일한 계산을 할 것이기 때문이다.
- w[0] == w[1]인 경우?
    - 정중앙을 기준으로 2개가 서로 대칭적으로 위치하거나, 정중앙에 하나만 있어야 한다.

## 어려움을 겪은 내용 & 해결 방법

### 1. 짝 맞추기

처음 설계할 때에는 words 배열의 모든 원소 w에 대하여 w[::-1]이 존재하면 답(res)을 2씩 증가하는 방식으로 구상하였다.

하지만 코드를 작성하던 중 words 배열에 있는 w와 w[::-1]의 개수가 서로 다르면 잘못된 답을 반환하게 된다는 사실을 발견하였다.

예를 들어, words = [’la’, ‘al’, ‘al’]이면 실제 답은 4가 나와야 하지만 위에 서술한 방식대로 계산하면 6이 나온다. 원소의 중복 사용이 불가능하므로 ‘al’ 2개 중 1개는 실제로는 짝이 없는데, 그 부분을 확인하지 못하고 넘어가는 것이다.

따라서, w의 개수와 w[::-1]의 개수 중 최솟값을 취하여 2를 곱해주는 식으로 계산하기로 하였다. 개수를 세기 위하여 collections 라이브러리의 Counter 함수를 사용하였다.

w[0] == w[1]일 경우(’aa’, ‘bb’, … ‘zz’) 다음 두 가지 배치 방법이 있다.

- 정중앙을 기준으로 같은 개수를 배치(총 개수는 짝수개가 됨)
- 정중앙에 하나만 배치

전자의 경우 w의 총 배치 개수는 짝수개가 되므로, 짝수라는 조건을 만족하면서 배치 개수가 최대로 되게 한다. w보다 작거나 같은 짝수 중 가장 큰 것을 취하면 된다(2 * (w의 개수 // 2)). w의 길이는 모두 2이므로 앞 식에 2를 곱한다.

w[0] == w[1]이면서 w가 1개인 경우, 정중앙에 배치할 수 있다. 개수가 1개인 w가 아무리 많아도 1개만 있는 w를 배치할 수 있는 곳은 정중앙 한 자리뿐이므로, bool 타입 변수를 사용하여 해당하는 경우가 있는지 없는지만 체크한다(unique_two_same_letters).

작성한 코드는 다음과 같다.

```python
class Solution:
    def longestPalindrome(self, words: List[str]) -> int:
        N = len(words)
        words_counter = collections.Counter(words)
        unique_two_same_letters = False
        res = 0
        
        for w in words_counter:
            if w[0] != w[1] and w[::-1] in words_counter:
                res += 2 * min(words_counter[w], words_counter[w[::-1]])
            elif w[0] == w[1]:
                res += 4 * (words_counter[w] // 2)
                if words_counter[w] == 1:
                    unique_two_same_letters = True
        
        return res if not unique_two_same_letters else res + 2
```

### 2. w[0] == w[1]인 경우의 처리

위 코드는 작동하지만 일부 테스트케이스에서 오답을 반환한다.

w[0] == w[1]인 w에 대하여, words 배열에 존재하는 w의 개수가 짝수개라면 모두 선택하여 답을 구성하지만, 홀수개라면 1개 빼고 선택하게 된다. 이 경우, 선택되지 않은 1개를 정중앙에 배치할 수 있다.

w[0] == w[1]인 경우를 계산할 때, 계산 과정을 생략하고 4를 곱하도록 한 것이 직관적이지 않아 w의 최대 배치 가능 개수(=w보다 작거나 같은 짝수 중 가장 큰 것)를 pair_count라는 변수에 저장하였다.

수정된 코드는 다음과 같다.

```python
class Solution:
    def longestPalindrome(self, words: List[str]) -> int:
        N = len(words)
        words_counter = collections.Counter(words)
        two_same_letters_center = False
        res = 0
        
        for w in words_counter:
            if w[0] != w[1] and w[::-1] in words_counter:
                res += 2 * min(words_counter[w], words_counter[w[::-1]])
            elif w[0] == w[1]:
                pair_count = 2 * (words_counter[w] // 2)
                res += 2 * pair_count
                **if words_counter[w] > pair_count:
                    two_same_letters_center = True**
        
        return res if not two_same_letters_center else res + 2
```