### PR TITLE
[21-22주차] yyj-Leetcode-416,473

### DIFF
--- a/Leetcode/416/yyj.py
+++ b/Leetcode/416/yyj.py
@@ -1,0 +1,23 @@
+class Solution:
+    def canPartition(self, nums: List[int]) -> bool:
+        
+        @lru_cache(None)
+        def finder(i: int, remain: int) -> bool:
+            if not remain:
+                return True
+            if i == N or remain < 0:
+                return False
+            
+            result = finder(i+1, remain-nums[i]) or finder(i+1, remain)
+            
+            return result
+            
+        
+        S = sum(nums)
+        N = len(nums)
+        if N <= 1 or S % 2 == 1:
+            return False
+        
+        target = S // 2
+        
+        return finder(0, target)

--- a/Leetcode/473/yyj.py
+++ b/Leetcode/473/yyj.py
@@ -1,0 +1,27 @@
+class Solution:
+    def makesquare(self, matchsticks: List[int]) -> bool:
+        
+        @lru_cache(None)
+        def finder(i, s1, s2, s3, s4) -> bool:
+            if i == N:
+                return s1 == s2 == s3 == s4
+            
+            return ( s1+matchsticks[i] <= target and finder(i+1, s1+matchsticks[i], s2, s3, s4)
+                or s2+matchsticks[i] <= target and finder(i+1, s1, s2+matchsticks[i], s3, s4)
+                or s3+matchsticks[i] <= target and finder(i+1, s1, s2, s3+matchsticks[i], s4)
+                or s4+matchsticks[i] <= target and finder(i+1, s1, s2, s3, s4+matchsticks[i]) )
+        
+        
+        N = len(matchsticks)
+        S = sum(matchsticks)
+        target = S // 4
+        
+        if N < 4 or S % 4:
+            return False
+        for stick in matchsticks:
+            if stick > target:
+                return False
+        
+        matchsticks = sorted(matchsticks, reverse=True)
+        
+        return finder(0, 0, 0, 0, 0)


### PR DESCRIPTION
## 문제

(https://leetcode.com/problems/partition-equal-subset-sum/)

## 개요

- 양의 정수만을 원소로 갖는 배열 nums가 주어진다.
- 이 배열을 두 개로 나눌 때, 나누어진 배열 2개의 합이 서로 같게 할 수 있으면 True, 그런 경우를 만드는 것이 불가능하면 False를 리턴한다.
    - 나누어진 배열을 A, B라고 할 때, nums의 모든 원소는 A와 B 중 하나에 반드시 속해야 하며, A와 B 모두에 속할 수는 없다.
    - nums의 모든 원소는 (값, 인덱스)에 따라 서로 구분된다. 즉, 값이 같더라도 인덱스가 다르면 다른 원소로 취급한다.

## 초기 설계

- 예외 처리 : 항상 거짓인 경우를 먼저 걸러낸다.
    - 배열의 길이가 1 이하인 경우 : 배열을 둘로 나눌 수 없다.
    - sum(nums)가 홀수인 경우 : 배열 nums의 모든 원소는 양의 정수이므로, 배열을 두 개로 나누었을 때 두 배열의 합이 같도록 할 수 없다.
- S = sum(nums)라고 하자(이 단계까지 오면 S의 값은 위의 예외처리에 의해  항상 짝수이다). 배열의 원소 몇 개를 골라 그 합이 S/2가 되면 True를 반환한다.
- finder(i, remain) : 현재 고를지 말지 결정할 원소의 index를 i, 앞으로 골라야 할 숫자들의 목표합을 remain이라 한다. i 이후의 원소를 적당히 골라 remain을 만들 수 있다면 True, 불가능하다면 False를 반환한다.
    - 처음 호출하는 형태는 finder(0, S/2)가 된다.
    - 이 함수는 i를 골랐을 때와 i를 고르지 않았을 때를 재귀호출하여 답을 구한다. 수많은 재귀호출 결과 중 하나라도 최종적으로 True가 되면 전체 답도 True가 되므로 OR로 연결한다.
        - i를 고른다 : finder(i+1, remain-nums[i])
        - i를 고르지 않는다 : finder(i+1, remain)
    - 중복 호출을 방지하기 위해 캐싱을 한다.

## 어려움을 겪은 내용 & 해결 방법

### 1. TLE or MLE?

아래 코드를 가동했더니 TLE가 나왔다. 캐싱을 하는데 왜 이럴까? 

```python
class Solution:
    def canPartition(self, nums: List[int]) -> bool:
        
        def finder(i: int, remain: int) -> bool:
            if not remain:
                return True
            if i >= N or remain < 0:
                return False
           
            if (i+1, remain-nums[i]) not in cache:
                cache[(i+1, remain-nums[i])] = finder(i+1, remain-nums[i])
            pick = cache[(i+1, remain-nums[i])]
                
            if (i+1, remain) not in cache:
                cache[(i+1, remain)] = finder(i+1, remain)
            not_pick = cache[(i+1, remain)]
            
            return pick | not_pick
            
        
        S = sum(nums)
        N = len(nums)
        if S % 2 == 1:
            return False
        
        cache = {}
        target = S // 2
        
        return finder(0, target)
```

캐시 설계를 잘못했나 생각이 들어 파이썬 데코레이터를 사용하여 Top-down 방식으로 바꾸었더니 MLE가 발생하였다.

```python
class Solution:
    def canPartition(self, nums: List[int]) -> bool:
        
        @lru_cache(None)
        def finder(i: int, remain: int) -> bool:
            ...
            
            result = finder(i+1, remain-nums[i]) | finder(i+1, remain)
            
            return result
            
        ...

        return finder(0, target)
```

bitwise ‘|’ 연산자를 logical ‘or’로 변경하였더니 통과하였다.

```python
class Solution:
    def canPartition(self, nums: List[int]) -> bool:
        
        @lru_cache(None)
        def finder(i: int, remain: int) -> bool:
            ...
            
            result = finder(i+1, remain-nums[i]) or finder(i+1, remain)
```

왜 이런 일이 일어났을까?

Python에서 logical operator ‘or’은 short-circuit evaluation이 적용되지만, bitwise operator ‘|’은 그렇지 않기 때문이다.

재귀 호출하는 경우 두 가지 finder(i+1, remain-nums[i]), finder(i+1, remain)를  short-circuit evaluation이 적용되지 않는 ‘|’로 연결하면, True가 되는 케이스를 찾아도 즉시 결과를 반환하지 않고 모든 재귀호출 식에 대한 계산을 수행한다.

OR 조건으로 연결된 식은 아무리 경우의 수가 많더라도 그 중 하나가 True이면 전체 식의 결과도 무조건 True가 되므로, 결과를 즉시 반환하지 못하면 불필요한 계산으로 시간과 자원을 낭비하는 것이 된다.

그렇다면 처음 작성했던 코드에서 ‘|’를 ‘or’로 바꾸면 통과할까? 그렇지는 않다. 캐시에 계산 결과가 없으면 계산 결과를 저장하기 위해 무조건 finder 함수를 재귀호출하므로, ‘|’를 ‘or’로 바꾸어도 short-circuit evaluation의 효과를 볼 수 없다.

<aside>
💡 Short-Circuit evaluation

</aside>

- 언어의 의미론적 특징(language semantic feature)
- 두 개 이상의 operand로 이루어진 operation의 결과를 도출할 때, 일부 operand만으로 결과를 확정할 수 있다면, 그 외 operand에 대한 계산을 하지 않고 즉시 결과를 반환한다.
- Python의 logical ‘or’ 작동방식
<html>
<body>
<!--StartFragment-->

operation | result | notes
-- | -- | --
x or y | x, if it evaluates to true, otherwise y. | y is evaluated if and only if x is false. If x is true, the operation returns true immediately because it suffices to determine its value.


<!--EndFragment-->
</body>
</html>
- bitwise or(’|’)은 short-circuit evaluation을 하지 않으므로, 항상 모든 operand에 대한 계산을 수행한다.

---

📔 References
[[Short-circuit evaluation - Wikipedia](https://en.wikipedia.org/wiki/Short-circuit_evaluation)](https://en.wikipedia.org/wiki/Short-circuit_evaluation)

[[Using the "or" Boolean Operator in Python - Real Python](https://realpython.com/python-or-operator/)](https://realpython.com/python-or-operator/)

[[How are lazy evaluation and short-circuit evaluation related?](https://www.quora.com/How-are-lazy-evaluation-and-short-circuit-evaluation-related)](https://www.quora.com/How-are-lazy-evaluation-and-short-circuit-evaluation-related)

[[Boolean operators vs Bitwise operators](https://stackoverflow.com/questions/3845018/boolean-operators-vs-bitwise-operators)](https://stackoverflow.com/questions/3845018/boolean-operators-vs-bitwise-operators)