### PR TITLE
[22주차] ygg-leetcode-73

### DIFF
--- a/Leetcode/73/ygg.py
+++ b/Leetcode/73/ygg.py
@@ -1,0 +1,49 @@
+class Solution:
+    def setZeroes(self, matrix: List[List[int]]) -> None:
+        """
+        Do not return anything, modify matrix in-place instead.
+        """
+        # matrix[n][0] takes rowchange role
+        # matrix[0][n] takes colchange role
+        rowchecked = False
+        colchecked = False
+        
+        for i in range(len(matrix)):
+            for j in range(len(matrix[0])):
+                if matrix[i][j] == 0:
+                    if i == 0: rowchecked = True
+                    if j == 0: colchecked = True
+                    matrix[i][0] = 0
+                    matrix[0][j] = 0
+        
+        for i in range(1, len(matrix)):
+            for j in range(1, len(matrix[0])):
+                if matrix[i][0] == 0 or matrix[0][j] == 0:
+                    matrix[i][j] = 0
+        
+        if rowchecked:
+            for j in range(len(matrix[0])):
+                matrix[0][j] = 0
+        if colchecked:
+            for i in range(len(matrix)):
+                matrix[i][0] = 0
+        
+#         rowchange = [0] * len(matrix)     
+#         colchange = [0] * len(matrix[0])  
+        
+#         for i in range(len(matrix)):
+#             for j in range(len(matrix[0])):
+#                 if matrix[i][j] == 0:
+#                     rowchange[i] = 1
+#                     colchange[j] = 1
+        
+#         for i, row in enumerate(rowchange):
+#             if row == 1:
+#                 for j in range(len(matrix[0])):
+#                     matrix[i][j] = 0
+#         for j, col in enumerate(colchange):
+#             if col == 1:
+#                 for i in range(len(matrix)):
+#                     matrix[i][j] = 0
+        
+        


### PR DESCRIPTION
## 문제
https://leetcode.com/problems/set-matrix-zeroes/
배열에 존재하는 모든 0이 속한 행과 열을 전체 0으로 세팅하기

## 어려움을 겪은 내용
공간복잡도 줄이기
1. 단순히 inplace 그대로 풀려고 하면 O(MN)
2. 내가 0으로 초기화 할 행과 열을 따로 저장하는 방식으로 공간복잡도 O(M+N) 까지는 접근했음
3. 문제에서 그 이하로 줄일 방법을 찾으라고 함..

## 해결 방법
0으로 세팅할 할 행과 열을 배열 0번째 행과 열에 저장해서 공간소비를 아예 없애버리는 방법
- 0번째 행렬이 아닌 각 원소에서 0 세팅 여부를 결정해야 함