### PR TITLE
[22주차] SUB-AtCoder-abc249-F

### DIFF
--- a/AtCoder/abc-259-F/SUB.py
+++ b/AtCoder/abc-259-F/SUB.py
@@ -1,4 +1,6 @@
+import sys
 import math
+sys.setrecursionlimit(10 ** 6)
 
 n = int(input())
 max_choice = list(map(int, input().split()))
@@ -9,8 +11,8 @@ dp = [[0 for _ in range(2)] for _ in range(300001)]
 
 for i in range(n-1):
     start, end, w = map(int, input().split())
-    arr[start].append([end, w])
-    arr[end]. append([start, w])
+    arr[start].append((end, w))
+    arr[end]. append((start, w))
 
 
 def dfs(cur, parent):
@@ -40,4 +42,3 @@ def dfs(cur, parent):
 
 dfs(1, -1)
 print(dp[1][1])
-

--- a/AtCoder/abc-259-F/SUB.py
+++ b/AtCoder/abc-259-F/SUB.py
@@ -1,0 +1,43 @@
+import math
+
+n = int(input())
+max_choice = list(map(int, input().split()))
+max_choice.insert(0, 0)
+
+arr = [[] for _ in range(n+1)]
+dp = [[0 for _ in range(2)] for _ in range(300001)]
+
+for i in range(n-1):
+    start, end, w = map(int, input().split())
+    arr[start].append([end, w])
+    arr[end]. append([start, w])
+
+
+def dfs(cur, parent):
+    childs = list()
+    for e in arr[cur]:
+        child = e[0]
+        weight = e[1]
+        if child == parent:
+            continue
+        dfs(child, cur)
+        childs.append(dp[child][0] + weight - dp[child][1])
+        dp[cur][0] += dp[child][1]
+        dp[cur][1] += dp[child][1]
+    childs.sort(reverse=True)
+
+    for i in range(len(childs)):
+        if childs[i] <= 0:
+            break
+        if i < max_choice[cur] - 1:
+            dp[cur][0] += childs[i]
+        if i < max_choice[cur]:
+            dp[cur][1] += childs[i]
+
+    if max_choice[cur] == 0:
+        dp[cur][0] = -math.inf
+
+
+dfs(1, -1)
+print(dp[1][1])
+


### PR DESCRIPTION
## 문제
<https://atcoder.jp/contests/abc259/tasks/abc259_f?lang=en>
노드가 N개 주어지고 간선이 N-1개 주어진다. 해당 그래프는 방향이 없는 그래프이고, 각 간선은 가중치를 가진다.
간선을 고르는 모든 경우 중에서 가중치의 합이 제일 큰 경우의 값을 구한다.
단, 각 노드에 대해서 연결된 간선 중 고를 수 있는 최대 개수가 주어진다.

## 어려움을 겪은 내용
고를 수 있는 간선의 수가 1인 노드부터 먼저 고르고 연결된 노드의 고를 수 있는 간선의 수를 1개씩 줄이면서 선택하는 방법을 취했으나 틀림
간선들을 가중치 기준으로 정렬하여 조건에 맞게 선택하는 방법도 틀렸다

## 해결 방법
DP로 풀어야 하는 문제

한 노드 v에 대해서 v와 연결된 간선 e에 대해서, 해당 간선을 고르는 경우와 고르지 않는 경우가 있다. 각각의 선택은 다음과 같은 결과가 발생한다.

1. e를 고르는 경우: 해당 간선과 연결된 자식 노드 u가 고를 수 있는 최대 간선의 개수가 1개 줄어든다
2. e를 고르지 않는 경우: 해당 간선과 연결된 자식 노드 u가 고를 수 있는 최대 간선의 개수는 유지된다.

따라서 e를 고르는 경우, 1번을 선택 했을 때의 dp[u]의 값에서 2번을 선택 했을 때의 dp[u]값을 빼고, e의 가중치만큼 더한 만큼 dp값에 변화가 일어난다.
이를 이용하여 e를 고르는 경우와 고르지 않는 경우 중 어느 쪽이 더 유리한지 알 수 있다.
코드에서는 1번을 선택하는 경우를 dp[u][0], 고르는 경우를 dp[u][1]에 저장하였다.

dp[v]는 먼저 연결된 노드들의 dp[u][1](최대 선택개수 만큼 선택한 경우 == v와 u를 잇는 간선을 고르지 않은 경우)의 합을 가지고 시작하고, 그 후에 연결된 간선을 골랐을 때 발생하는 각각의 차이를 list에 저장하여 정렬한 다음, 최대 선택 개수에 맞게 골라서 추가로 더해준다.
이때, 최대선택개수 - 1개만큼은 dp[v][0]과 dp[v][1] 두 곳에 모두 더해주고, 최대선택개수 번째의 값은 dp[v][1]에만 더해준다

## 몰라서 헤맸던 점
- 문제의 조건이 N개의 노드와 N-1개의 간선이 주어진 다는 것인데, 이런 경우 그래프에 사이클이 발생하지 않는다. 다각형을 생각하면 편함(삼각형은 꼭지점에 3개, 모서리가 3개). 따라서 dfs를 만들 때 이를 고려하지 않아도 됨.
- 그래프 정보를 입력할 때, graph.append([u, w])와 같은 식으로 []를 사용하였는데, 튜플인 ()를 사용해야 더 빨랐다. 테스트 케이스에 따라서는 시간초과가 발생
- 재귀호출을 많이 사용 할 경우, sys.setrecursionlimit()를 이용하여 재귀 깊이 제한을 늘려줘야 한다.

![image](https://user-images.githubusercontent.com/31717041/178985545-bae0f03d-7c91-4bb8-845f-07b439e99ce4.png)
