### PR TITLE
[23주차] SUB-AtCoder-abc-260-D

### DIFF
--- a/AtCoder/abc-260-D/SUB.py
+++ b/AtCoder/abc-260-D/SUB.py
@@ -1,0 +1,46 @@
+n, k = map(int, input().split())
+
+cards = list(map(int, input().split()))
+dic = dict()
+arr = []
+
+for i in range(len(cards)):
+    cur = cards[i]
+
+    if len(arr) == 0 or arr[-1][-1] < cur:
+        arr.append([cur])
+        if len(arr[-1]) >= k:
+            for e in arr[-1]:
+                dic[e] = i + 1
+            del arr[-1]
+    elif cur < arr[0][-1]:
+        arr[0].append(cur)
+        if len(arr[0]) >= k:
+            for e in arr[0]:
+                dic[e] = i + 1
+            del arr[0]
+    else:
+        start = 0
+        end = len(arr) - 1
+
+        while start <= end:
+            mid = (start + end) // 2
+
+            if arr[mid][-1] < cur < arr[mid+1][-1]:
+                arr[mid+1].append(cur)
+
+                if len(arr[mid+1]) >= k:
+                    for e in arr[mid+1]:
+                        dic[e] = i + 1
+                    del arr[mid+1]
+                    break
+            elif arr[mid + 1][-1] < cur:
+                start = mid + 1
+            else:
+                end = mid - 1
+
+for i in range(1, n+1):
+    if i not in dic:
+        print(-1)
+    else:
+        print(dic[i])


### PR DESCRIPTION
## 문제
<https://atcoder.jp/contests/abc260/tasks/abc260_d?lang=en>
1부터 N까지의 카드가 무작위로 섞여있다.
카드를 하나 뽑아서 해당 카드보다 큰 숫자가 존재할 경우, 그 숫자들 중 가장 작은 숫자 위에 올려놓는다. 그리고 이를 반복한다.
쌓인 카드가 K장이 되었을 경우 해당 카드 뭉치를 모두 제거한다.
1부터 N까지의 카드가 각각 몇번째 행동에서 제거되었는지 출력한다. 마지막까지 제거되지 않고 남아있는 경우 -1을 출력한다.

1≤K≤N≤2×10^55

(예시)
![image](https://user-images.githubusercontent.com/31717041/179969794-c3b16c91-b719-4a8f-8c49-b2b41176dd80.png)

## 어려움을 겪은 내용
입력의 크기에 의해서 해당 카드가 어느 위치에 존재해야 하는 지를 찾으려면 이분법을 사용해야 시간 내에 계산 가능하다는 것 까지는 도출해냈으나, 몇 개의 테스트 케이스가 TLE가 발생하였는데, 원인을 찾지 못함.

## 해결 방법
카드 전체를 각 element가 리스트로 이루어진 리스트 (list(list())) 로 관리하고, 쌓인 카드뭉치의 제일 윗부분을 list[0]로 확인하는 구조로 만들었다. 그리고 카드뭉치 제일 위에 올려놓는 작업을 할 때, list의 맨 앞부분에 insert하는 식으로 구현하였는데, insert의 시간복잡도가 O(N)이기 때문에 시간초과가 발생하였다.
따라서 insert대신 append를 사용하였고, 해당 카드뭉치의 제일 윗부분을 참조할 때 list[-1]로 확인하도록 만들었더니 통과되었다.
수정 전:
```python
start = 0
end = len(arr) - 1

while start <= end:
    mid = (start + end) // 2

    if arr[mid][0] < cur < arr[mid+1][0]:
        arr[mid+1].insert(0, cur)

        if len(arr[mid+1]) >= k:
            for e in arr[mid+1]:
                dic[e] = i + 1
            del arr[mid+1]
            break
    elif arr[mid + 1][0] < cur:
        start = mid + 1
    else:
    end = mid - 1
```

수정 후
```python
start = 0
end = len(arr) - 1

while start <= end:
    mid = (start + end) // 2

    if arr[mid][-1] < cur < arr[mid+1][-1]:
        arr[mid+1].append(cur)

        if len(arr[mid+1]) >= k:
            for e in arr[mid+1]:
                dic[e] = i + 1
            del arr[mid+1]
            break
    elif arr[mid + 1][-1] < cur:
        start = mid + 1
    else:
    end = mid - 1
```

랭크 변동 56->180