### PR TITLE
[24주차] ygg-leetcode-131

### DIFF
--- a/Leetcode/131/ygg.py
+++ b/Leetcode/131/ygg.py
@@ -1,0 +1,33 @@
+class Solution:
+    @cache
+    def check(self, s):
+        for i in range(len(s) // 2):
+            if s[i] != s[len(s) - i - 1]:
+                return False
+        return True
+    
+    #@cache # cache is shallow copy
+    def comb(self, s: str) -> List[List[str]]:
+        if len(s) == 1:
+            return [[s]]
+        
+        ans = []
+        for i in range(1, len(s)):
+            if False == self.check(s[:i]):
+                continue
+            
+            cand = self.comb(s[i:])
+            for j in range(len(cand)):
+                cand[j] = [s[:i]] + cand[j]
+                
+            ans += cand
+            
+        if self.check(s):
+            ans += [[s]]
+        
+        return ans
+    
+    def partition(self, s: str) -> List[List[str]]:
+        return self.comb(s)
+
+        


### PR DESCRIPTION
## 문제
https://leetcode.com/problems/palindrome-partitioning/
모든 substring이 palindrome이 되는 partition의 조합 모두 구하기

## 어려움을 겪은 내용
@cache가 생각대로 동작하지 않아 어려움을 겪음
cache의 output이 list 일 경우 shallow copy가 되는 것으로 추정

## 해결 방법
개수가 16이므로 brute force 로 확인
- 다만 매 분할마다 palindrome 을 확인하여 정답이 아닌 조합을 바로 걸러냄
