### PR TITLE
[26주차] ygg-Leetcode-239

### DIFF
--- a/Leetcode/239/ygg.py
+++ b/Leetcode/239/ygg.py
@@ -1,0 +1,56 @@
+from collections import deque
+
+
+class Solution:
+    def maxSlidingWindow(self, nums: List[int], k: int) -> List[int]:
+        l = len(nums)
+
+        if l == 1 or k == 1:
+            return nums
+
+        dq = deque()
+        dq.append(nums[0])
+
+        for n in nums[1:k]:
+            while dq and n > dq[-1]:
+                dq.pop()
+
+            if not dq or n > dq[0]:
+                dq.appendleft(n)
+            else:
+                dq.append(n)
+
+        ans = [dq[0]]
+        for i in range(k, l):
+            n = nums[i]
+
+            if dq and nums[i - k] == dq[0]:
+                dq.popleft()
+
+            while dq and n > dq[-1]:
+                dq.pop()
+
+            if not dq or n > dq[0]:
+                dq.appendleft(n)
+            else:
+                dq.append(n)
+
+            ans.append(dq[0])
+
+        return ans
+
+#         # TLE
+#         l = len(nums)
+
+#         if l == 1 or k == 1:
+#             return nums
+
+#         ans = [0] * l
+#         for i, n in enumerate(nums):
+#             for j in range(k):
+#                 if i - j >= 0 and n >= nums[i - j]:
+#                     ans[i - j] = n
+#                 else:
+#                     break
+
+#         return ans[:-(k-1)]


### PR DESCRIPTION
## 문제
https://leetcode.com/problems/sliding-window-maximum/
각 sliding window 마다 최대값 구하기

## 어려움을 겪은 내용
각 element 를 순회하면서 k 범위만큼 max 값을 update 하자
 → O(n) * (상수) 인 줄 알았으나 O(n*k) = O(n^2) 이었음.. TLE

max 값 update는 어렵지 않으나,
- max 값이 sliding window 에서 빠졌을 때 다음 max값이 무엇인지 찾거나 (nlogn이 가능한가..)
- sliding window 안에서 값이 큰 순서대로 정렬하고 각 원소를 넣고 뺄 때 위치 탐색 (O(nlogn)이 보장되는 R/B, B*, AVL 등의 tree)
둘 중 하나를 구현해야 한다.


## 해결 방법
sliding window 안에서 값이 큰 순서대로 가지고 있되, 삽입할 원소보다 큰 값만 가지는 deque
- 삽입은 항상 max 또는 min (앞/뒤 append) 만 수행
- 제거는?
  - 삽입할 값보다 작은 값들을 전부 제거 (뒤쪽 pop)